### PR TITLE
Fix user email not required

### DIFF
--- a/app/Panel/Conference/Resources/UserResource.php
+++ b/app/Panel/Conference/Resources/UserResource.php
@@ -101,6 +101,7 @@ class UserResource extends Resource
                                 Forms\Components\TextInput::make('family_name')
                                     ->label(__('general.family_name')),
                                 Forms\Components\TextInput::make('email')
+                                    ->required()
                                     ->label(__('general.email'))
                                     ->columnSpan(['lg' => 2])
                                     ->disabled(fn (?User $record) => $record)


### PR DESCRIPTION
This pull request fixes an issue where the user email field was not marked as required. The commit includes a patch that adds the required attribute to the email input field in the form.