### PR TITLE
feat: implement multilanguage support for Announcement model

### DIFF
--- a/app/Actions/Announcements/AnnouncementCreateAction.php
+++ b/app/Actions/Announcements/AnnouncementCreateAction.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Announcements;
 
+use App\Facades\Setting;
 use App\Models\Announcement;
 use Illuminate\Support\Facades\DB;
 use Lorisleiva\Actions\Concerns\AsAction;
@@ -15,9 +16,27 @@ class AnnouncementCreateAction
         try {
             DB::beginTransaction();
 
-            $announcement = Announcement::create($data);
-            if (data_get($data, 'meta')) {
-                $announcement->setManyMeta(data_get($data, 'meta'));
+            // Handle multilanguage data
+            $primaryLocale = Setting::get('default_language', app()->getLocale());
+            $processedData = $data;
+
+            // Extract title for primary locale and save to main field
+            if (isset($data['title'][$primaryLocale])) {
+                $processedData['title'] = $data['title'][$primaryLocale];
+            }
+
+            // Prepare meta data for multilanguage
+            $metaData = data_get($data, 'meta', []);
+
+            // Store multilanguage title in meta
+            if (isset($data['title']) && is_array($data['title'])) {
+                $metaData['title'] = $data['title'];
+            }
+
+            $announcement = Announcement::create($processedData);
+
+            if ($metaData) {
+                $announcement->setManyMeta($metaData);
             }
 
             if ($sendEmail) {

--- a/app/Actions/Announcements/AnnouncementUpdateAction.php
+++ b/app/Actions/Announcements/AnnouncementUpdateAction.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Announcements;
 
+use App\Facades\Setting;
 use App\Models\Announcement;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
@@ -16,10 +17,27 @@ class AnnouncementUpdateAction
         try {
             DB::beginTransaction();
 
-            $announcement->update($data);
+            // Handle multilanguage data
+            $primaryLocale = Setting::get('default_language', app()->getLocale());
+            $processedData = $data;
 
-            if (data_get($data, 'meta')) {
-                $announcement->setManyMeta(data_get($data, 'meta'));
+            // Extract title for primary locale and save to main field
+            if (isset($data['title'][$primaryLocale])) {
+                $processedData['title'] = $data['title'][$primaryLocale];
+            }
+
+            // Prepare meta data for multilanguage
+            $metaData = data_get($data, 'meta', []);
+
+            // Store multilanguage title in meta
+            if (isset($data['title']) && is_array($data['title'])) {
+                $metaData['title'] = $data['title'];
+            }
+
+            $announcement->update($processedData);
+
+            if ($metaData) {
+                $announcement->setManyMeta($metaData);
             }
 
             DB::commit();

--- a/app/Models/Announcement.php
+++ b/app/Models/Announcement.php
@@ -3,16 +3,16 @@
 namespace App\Models;
 
 use App\Models\Concerns\BelongsToScheduledConference;
+use App\Models\Concerns\LocalizedMetable;
 use GeneaLabs\LaravelModelCaching\Traits\Cachable;
 use Illuminate\Database\Eloquent\Model;
-use Plank\Metable\Metable;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 class Announcement extends Model implements HasMedia
 {
-    use BelongsToScheduledConference, Cachable, InteractsWithMedia, Metable;
+    use BelongsToScheduledConference, Cachable, InteractsWithMedia, LocalizedMetable;
 
     protected $fillable = [
         'title',
@@ -45,5 +45,29 @@ class Announcement extends Model implements HasMedia
         $this->addMediaConversion('thumb-xl')
             ->keepOriginalImageFormat()
             ->width(600);
+    }
+
+    /**
+     * Get localized title
+     */
+    public function getLocalizedTitle(?string $locale = null): string
+    {
+        return $this->getLocalizedMeta('title', $locale) ?? $this->title ?? '';
+    }
+
+    /**
+     * Get localized summary
+     */
+    public function getLocalizedSummary(?string $locale = null): ?string
+    {
+        return $this->getLocalizedMeta('summary', $locale);
+    }
+
+    /**
+     * Get localized content
+     */
+    public function getLocalizedContent(?string $locale = null): ?string
+    {
+        return $this->getLocalizedMeta('content', $locale);
     }
 }

--- a/app/Panel/ScheduledConference/Resources/AnnouncementResource.php
+++ b/app/Panel/ScheduledConference/Resources/AnnouncementResource.php
@@ -4,6 +4,7 @@ namespace App\Panel\ScheduledConference\Resources;
 
 use App\Actions\Announcements\AnnouncementUpdateAction;
 use App\Facades\Setting;
+use App\Filament\Forms\Components\MultilanguageComponent;
 use App\Forms\Components\TinyEditor;
 use App\Models\Announcement;
 use App\Panel\ScheduledConference\Resources\AnnouncementResource\Pages;
@@ -48,16 +49,18 @@ class AnnouncementResource extends Resource
     {
         return $form
             ->schema([
-                TextInput::make('title')
-                    ->label(__('general.title'))
-                    ->required(),
-                Textarea::make('meta.summary')
-                    ->label(__('general.summary'))
-                    ->autosize(),
-                TinyEditor::make('meta.content')
-                    ->label(__('general.announcement'))
-                    ->profile('basic')
-                    ->helperText(__('general.complete_announcement_content')),
+                MultilanguageComponent::make([
+                    TextInput::make('title')
+                        ->label(__('general.title'))
+                        ->required(),
+                    Textarea::make('meta.summary')
+                        ->label(__('general.summary'))
+                        ->autosize(),
+                    TinyEditor::make('meta.content')
+                        ->label(__('general.announcement'))
+                        ->profile('basic')
+                        ->helperText(__('general.complete_announcement_content')),
+                ]),
                 DatePicker::make('expires_at')
                     ->label(__('general.expires_at'))
                     ->minDate(today()->addDay()),
@@ -96,7 +99,26 @@ class AnnouncementResource extends Resource
                     ->color('gray'),
                 EditAction::make()
                     ->mutateRecordDataUsing(function (Announcement $record, array $data) {
-                        $data['meta'] = $record->getAllMeta()->toArray();
+                        $meta = $record->getAllMeta()->toArray();
+                        $data['meta'] = $meta;
+
+                        // Handle multilanguage data loading
+                        $locales = Setting::get('languages', [app()->getLocale()]);
+                        foreach ($locales as $locale) {
+                            if (isset($meta['title'][$locale])) {
+                                $data['title'][$locale] = $meta['title'][$locale];
+                            }
+                            if (isset($meta['summary'][$locale])) {
+                                $data['meta']['summary'][$locale] = $meta['summary'][$locale];
+                            }
+                            if (isset($meta['content'][$locale])) {
+                                $data['meta']['content'][$locale] = $meta['content'][$locale];
+                            }
+                        }
+
+                        // Set primary locale data from database fields
+                        $primaryLocale = Setting::get('default_language', app()->getLocale());
+                        $data['title'][$primaryLocale] = $record->title;
 
                         return $data;
                     })


### PR DESCRIPTION
- Add LocalizedMetable trait to Announcement model
- Implement MultilanguageComponent in AnnouncementResource form
- Update AnnouncementCreateAction to handle multilanguage data
- Update AnnouncementUpdateAction to handle multilanguage data
- Add helper methods for localized content retrieval
- Support for title, summary, and content in multiple languages