### PR TITLE
Fix self-assign role allowlist validation

### DIFF
--- a/app/Panel/ScheduledConference/Widgets/WelcomeAndSelfAssignRole.php
+++ b/app/Panel/ScheduledConference/Widgets/WelcomeAndSelfAssignRole.php
@@ -85,7 +85,7 @@ class WelcomeAndSelfAssignRole extends Widget
 
         $selectedRoleInput = $this->formData['role'] ?? null;
 
-        if (!$selectedRoleInput && is_string($selectedRoleInput) && in_array($selectedRoleInput, $allowedRoles, true)) {
+        if (!is_string($selectedRoleInput) || !in_array($selectedRoleInput, $allowedRoles, true)) {
             Notification::make()
                 ->warning()
                 ->title(__('general.no_roles_selected'))


### PR DESCRIPTION
### Motivation
- The Livewire `WelcomeAndSelfAssignRole::submitRoles()` previously accepted arbitrary `formData.role` values because the validation condition was inverted, allowing tampered payloads to pass privileged role names (e.g. `Admin`) to `assignRole()` and enabling privilege escalation.

### Description
- Corrected the validation in `app/Panel/ScheduledConference/Widgets/WelcomeAndSelfAssignRole.php` so `submitRoles()` now rejects any value that is not a string or is not present in `UserRole::getAllowedSelfAssignRoleNames()` before calling `assignRole()`, preserving existing notifications and flow.

### Testing
- Ran `php -l app/Panel/ScheduledConference/Widgets/WelcomeAndSelfAssignRole.php` and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d6acd3700832684321780d5df4346)