### PR TITLE
Harden staging bootstrap configuration to require APP_KEY and admin credentials

### DIFF
--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -43,11 +43,13 @@ services:
       PHP_OPCACHE_ENABLE: "0"
       PHP_FPM_PM_MAX_CHILDREN: "5"
       APP_ENV: production
-      APP_KEY: base64:yv7ba7W38mH8WC06OAWcokwKhfyaiNR4ranj0gWS7aw=
-      APP_DEBUG: "true"
+      APP_KEY: ${APP_KEY:?APP_KEY is required for staging}
+      APP_DEBUG: ${APP_DEBUG:-"false"}
       APP_URL: http://leconfe-staging-${STAGING_PR}-${STAGING_IP}.nip.io
       APP_INSTALLED: "true"
       APP_QUICK_SETUP: "true"
+      APP_ADMIN_EMAIL: ${APP_ADMIN_EMAIL:?APP_ADMIN_EMAIL is required when APP_QUICK_SETUP is enabled}
+      APP_ADMIN_PASSWORD: ${APP_ADMIN_PASSWORD:?APP_ADMIN_PASSWORD is required when APP_QUICK_SETUP is enabled}
       DB_CONNECTION: mysql
       DB_HOST: leconfe-staging-db-${STAGING_PR}
       DB_PORT: "3306"


### PR DESCRIPTION
### Motivation
- Staging configuration exposed public instances with `APP_QUICK_SETUP=true`, a hardcoded `APP_KEY`, and `APP_DEBUG=true`, which allowed unattended creation of a predictable Admin account.
- The default quick-install behavior falls back to `admin@leconfe.com` / `admin` when admin env vars are not provided, enabling remote unauthenticated takeover of staging instances.

### Description
- Updated `docker-compose.staging.yml` to require `APP_KEY` from the environment by replacing the hardcoded key with `APP_KEY: ${APP_KEY:?APP_KEY is required for staging}`.
- Changed `APP_DEBUG` to default to `false` with `APP_DEBUG: ${APP_DEBUG:-"false"}` to avoid enabling debug in public staging by default.
- Added required environment checks for `APP_ADMIN_EMAIL` and `APP_ADMIN_PASSWORD` when quick setup is enabled using `APP_ADMIN_EMAIL: ${APP_ADMIN_EMAIL:?APP_ADMIN_EMAIL is required when APP_QUICK_SETUP is enabled}` and `APP_ADMIN_PASSWORD: ${APP_ADMIN_PASSWORD:?APP_ADMIN_PASSWORD is required when APP_QUICK_SETUP is enabled}`.
- The quick-install flow in `app/Actions/Leconfe/QuickInstall.php` and the container entrypoint are left unchanged so the installer behavior is preserved when explicit credentials and keys are supplied.

### Testing
- No automated test suite was executed for this configuration-only change.
- Local validations were performed by inspecting `docker-compose.staging.yml` and using `rg`/`nl` to confirm the new environment variable requirements and defaults were applied successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d6b2d271c8326b191be516e84438a)