### PR TITLE
Reject invitation register for existing users to prevent account takeover

### DIFF
--- a/app/Frontend/Website/Pages/InvitationRegister.php
+++ b/app/Frontend/Website/Pages/InvitationRegister.php
@@ -9,6 +9,7 @@ use App\Models\UserInvitation;
 use Filament\Facades\Filament;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Validation\ValidationException;
 use Rahmanramsi\LivewirePageGroup\PageGroup;
 
 class InvitationRegister extends Page
@@ -74,14 +75,9 @@ class InvitationRegister extends Page
             ->first();
 
         if ($existingUser) {
-            $this->markInvitationEmailAsVerified($existingUser);
-
-            Filament::auth()->login($existingUser);
-            session()->regenerate();
-
-            AcceptUserInvitationAction::run($invitation, $existingUser);
-
-            return $this->redirect($this->getSuccessUrl($invitation), navigate: false);
+            throw ValidationException::withMessages([
+                'token' => 'An account already exists for this invitation email. Please sign in to accept the invitation.',
+            ]);
         }
 
         $user = UserCreateAction::run([


### PR DESCRIPTION
### Motivation
- Close an account-takeover vector where a copied invitation token could be used to authenticate an existing user without their password by rejecting register submissions for emails that already belong to a user.

### Description
- Modified `app/Frontend/Website/Pages/InvitationRegister.php` to import `ValidationException` and throw `ValidationException::withMessages(['token' => 'An account already exists for this invitation email. Please sign in to accept the invitation.'])` when the invitation email matches an existing user, instead of logging that user in automatically; the new-user invitation flow remains unchanged.

### Testing
- Ran `php -l app/Frontend/Website/Pages/InvitationRegister.php` and there were no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d7a339cec8326bf2844a07472ca1b)