### PR TITLE
Add server-side authorization to plugin ZIP upload action

### DIFF
--- a/app/Panel/Administration/Pages/PluginManagement.php
+++ b/app/Panel/Administration/Pages/PluginManagement.php
@@ -52,6 +52,7 @@ class PluginManagement extends Page implements HasForms, HasInfolists
             Action::make('upload-plugin')
                 ->label(__('general.upload_plugin'))
                 ->modalHeading(__('general.upload_plugin'))
+                ->authorize(fn () => auth()->user()->can('install', Plugin::class))
                 ->visible(fn () => auth()->user()->can('install', Plugin::class))
                 ->form([
                     FileUpload::make('file')


### PR DESCRIPTION
### Motivation
- Prevent an authorization bypass in the `upload-plugin` Filament header action that allowed a hidden Livewire action to invoke `PluginFacade::install(...)` and thereby execute attacker-supplied PHP during plugin installation.

### Description
- Added a server-side authorization guard `->authorize(fn () => auth()->user()->can('install', Plugin::class))` to the `upload-plugin` header action in `app/Panel/Administration/Pages/PluginManagement.php` while preserving the existing `->visible(...)` UI check and upload workflow.

### Testing
- Ran `php -l app/Panel/Administration/Pages/PluginManagement.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0db0fbb45c832694f5efed2301ee48)