### PR TITLE
Add server-side authorization to PluginGallery install Livewire method

### DIFF
--- a/app/Panel/Administration/Livewire/PluginGalleryTable.php
+++ b/app/Panel/Administration/Livewire/PluginGalleryTable.php
@@ -104,6 +104,8 @@ class PluginGalleryTable extends Component implements HasForms, HasTable
 
     public function install(PluginGallery $record)
     {
+        abort_unless(auth()->user()?->can('install', $record), 403);
+
         $message = $record->isUpgradable() ? 'Upgrade' : 'Install';
 
         $process = $record->install();


### PR DESCRIPTION
### Motivation
- Prevent a critical authorization bypass where the public Livewire method could be invoked to download and install executable plugin code by low-privilege users, by enforcing the `PluginGallery` install policy on the server side.

### Description
- Added a server-side guard `abort_unless(auth()->user()?->can('install', $record), 403);` at the start of `PluginGalleryTable::install()` (`app/Panel/Administration/Livewire/PluginGalleryTable.php`) so the `PluginGalleryPolicy::install` check is enforced before any download or installation logic runs.

### Testing
- Ran `php -l app/Panel/Administration/Livewire/PluginGalleryTable.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0daec615508326875c64d34aa88afa)