### PR TITLE
fix: disable Composer scripts/plugins for plugin staging installs

### DIFF
--- a/bin/setup-staging.sh
+++ b/bin/setup-staging.sh
@@ -36,7 +36,7 @@ find plugins -maxdepth 2 -name composer.json -not -path "*/vendor/*" | sort | wh
     plugin_dir=$(dirname "$plugin_composer")
     if [ -f "$plugin_dir/composer.lock" ]; then
         echo "  Installing dependencies for $plugin_dir ..."
-        (cd "$plugin_dir" && composer install --no-dev --optimize-autoloader --no-interaction --ignore-platform-reqs 2>&1 | sed 's/^/    /') || echo "  Warning: composer install failed for $plugin_dir, continuing..."
+        (cd "$plugin_dir" && composer install --no-dev --optimize-autoloader --no-scripts --no-plugins --no-interaction --ignore-platform-reqs 2>&1 | sed 's/^/    /') || echo "  Warning: composer install failed for $plugin_dir, continuing..."
     fi
 done
 


### PR DESCRIPTION
### Motivation
- Prevent execution of Composer scripts or plugins from attacker-controlled plugin manifests during staging setup by hardening plugin-level dependency installation, matching the protections used for the root install.

### Description
- Add `--no-scripts --no-plugins` to the plugin `composer install` invocation in `bin/setup-staging.sh` so plugin installs cannot run Composer scripts or plugins.

### Testing
- Ran `git diff -- bin/setup-staging.sh && rg -n "composer install --no-dev" bin/setup-staging.sh` and confirmed the plugin install now includes `--no-scripts --no-plugins`, and the subsequent `git commit` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d65d7e084832698294cf8b400706c)