### PR TITLE
Enforce plugin install authorization in gallery install action

### DIFF
--- a/app/Panel/Administration/Livewire/PluginGalleryTable.php
+++ b/app/Panel/Administration/Livewire/PluginGalleryTable.php
@@ -104,6 +104,8 @@ class PluginGalleryTable extends Component implements HasForms, HasTable
 
     public function install(PluginGallery $record)
     {
+        abort_unless(auth()->user()->can('install', $record), 403);
+
         $message = $record->isUpgradable() ? 'Upgrade' : 'Install';
 
         $process = $record->install();


### PR DESCRIPTION
### Motivation
- Prevent administration-panel users who lack `Plugin:install` permission from triggering gallery installs via Livewire and thereby avoiding the existing `PluginPolicy::install` guard.

### Description
- Add a server-side authorization guard `abort_unless(auth()->user()->can('install', $record), 403);` at the start of `PluginGalleryTable::install()` so the policy is enforced before any install/upgrade is executed.

### Testing
- Ran `php -l app/Panel/Administration/Livewire/PluginGalleryTable.php` with no syntax errors and reviewed the `git diff` to confirm only the authorization check was added and the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0daff4558c8326aca2d993ab61adaf)