### PR TITLE
Require non-default APP_ADMIN_PASSWORD for quick-install

### DIFF
--- a/app/Actions/Leconfe/QuickInstall.php
+++ b/app/Actions/Leconfe/QuickInstall.php
@@ -35,10 +35,17 @@ class QuickInstall
             return;
         }
 
+        $adminPassword = env('APP_ADMIN_PASSWORD');
+        if (blank($adminPassword) || $adminPassword === 'admin') {
+            alert('Quick install requires APP_ADMIN_PASSWORD to be set to a non-default value.');
+
+            return;
+        }
+
         $data = [
             'given_name' => 'Admin',
             'email' => env('APP_ADMIN_EMAIL', 'admin@leconfe.com'),
-            'password' => Hash::make(env("APP_ADMIN_PASSWORD", 'admin')),
+            'password' => Hash::make($adminPassword),
         ];
 
         try {


### PR DESCRIPTION
### Motivation
- The Docker quick-install path could create an admin user with known default credentials when `APP_QUICK_SETUP` is enabled, exposing a critical unauthenticated admin account.

### Description
- Add a guard that aborts quick install if `APP_ADMIN_PASSWORD` is missing or still set to the insecure default `admin`, and use the validated `APP_ADMIN_PASSWORD` value when hashing the installer payload.

### Testing
- Ran `php -l app/Actions/Leconfe/QuickInstall.php` and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d8ca56b30832681156f4c5fb13d28)