### PR TITLE
Fix invitation registration email verification bypass

### DIFF
--- a/app/Frontend/Website/Pages/InvitationRegister.php
+++ b/app/Frontend/Website/Pages/InvitationRegister.php
@@ -74,7 +74,7 @@ class InvitationRegister extends Page
             ->first();
 
         if ($existingUser) {
-            $this->markInvitationEmailAsVerified($existingUser);
+            $this->sendInvitationEmailVerificationNotification($existingUser);
 
             Filament::auth()->login($existingUser);
             session()->regenerate();
@@ -91,7 +91,7 @@ class InvitationRegister extends Page
             'password' => $this->password,
         ]);
 
-        $this->markInvitationEmailAsVerified($user);
+        $this->sendInvitationEmailVerificationNotification($user);
 
         Filament::auth()->login($user);
         session()->regenerate();
@@ -156,14 +156,12 @@ class InvitationRegister extends Page
         return route('filament.administration.home');
     }
 
-    protected function markInvitationEmailAsVerified(User $user): void
+    protected function sendInvitationEmailVerificationNotification(User $user): void
     {
-        if ($user->hasVerifiedEmail()) {
+        if (! config('app.must_verify_email') || $user->hasVerifiedEmail()) {
             return;
         }
 
-        $user->forceFill([
-            'email_verified_at' => now(),
-        ])->saveQuietly();
+        $user->sendEmailVerificationNotification();
     }
 }

--- a/tests/Feature/InvitationRegisterTest.php
+++ b/tests/Feature/InvitationRegisterTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Frontend\Website\Pages\InvitationRegister;
+use App\Mail\Templates\VerifyUserEmail;
 use App\Models\Conference;
 use App\Models\Role;
 use App\Models\User;
@@ -17,7 +18,7 @@ class InvitationRegisterTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_invitation_registration_marks_new_user_email_as_verified(): void
+    public function test_invitation_registration_keeps_new_user_unverified_and_sends_verification_email(): void
     {
         Config::set('app.must_verify_email', true);
         Mail::fake();
@@ -49,16 +50,16 @@ class InvitationRegisterTest extends TestCase
             ->where('email', 'invitee@example.com')
             ->firstOrFail();
 
-        $this->assertNotNull($user->email_verified_at);
+        $this->assertNull($user->email_verified_at);
         $this->assertAuthenticatedAs($user);
         $this->assertDatabaseHas('user_invitations', [
             'id' => $invitation->id,
             'status' => 'accepted',
         ]);
-        Mail::assertNothingSent();
+        Mail::assertSent(VerifyUserEmail::class, 1);
     }
 
-    public function test_invitation_registration_marks_existing_user_email_as_verified(): void
+    public function test_invitation_registration_keeps_existing_user_unverified_and_sends_verification_email(): void
     {
         Config::set('app.must_verify_email', true);
         Mail::fake();
@@ -95,13 +96,13 @@ class InvitationRegisterTest extends TestCase
 
         $user->refresh();
 
-        $this->assertNotNull($user->email_verified_at);
+        $this->assertNull($user->email_verified_at);
         $this->assertAuthenticatedAs($user);
         $this->assertDatabaseHas('user_invitations', [
             'id' => $invitation->id,
             'status' => 'accepted',
         ]);
-        Mail::assertNothingSent();
+        Mail::assertSent(VerifyUserEmail::class, 1);
     }
 
     protected function createInvitationRole(Conference $conference): void


### PR DESCRIPTION
### Motivation
- The invitation registration flow treated possession of an invitation token as proof of mailbox ownership by writing `email_verified_at` unconditionally, allowing an authenticated inviter to create or accept invitations for arbitrary emails and obtain verified, role-bearing accounts.
- The intent of the change is to restore email verification as a real gate when `app.must_verify_email` is enabled and avoid implicitly marking accounts verified based only on invitation-token possession.

### Description
- Replace the helper that force-wrote `email_verified_at` with `sendInvitationEmailVerificationNotification`, which calls `sendEmailVerificationNotification()` instead of mutating the `email_verified_at` column. 
- The new helper short-circuits when `config('app.must_verify_email')` is disabled or the user is already verified, and otherwise dispatches the verification email.
- Both existing-user and new-user invitation registration paths now call the notification helper instead of setting `email_verified_at`, while preserving the login and `AcceptUserInvitationAction` behavior.
- Updated `tests/Feature/InvitationRegisterTest.php` to assert that invited users remain unverified immediately after registration and that a `VerifyUserEmail` mail is sent.

### Testing
- Attempted to run `php artisan test --filter=InvitationRegisterTest`, but the run failed in this environment with `Failed opening required '/workspace/leconfe/vendor/autoload.php'` because project dependencies are not installed, so tests could not be executed here.
- The feature tests were updated to reflect the secure behavior (`assertNull($user->email_verified_at)` and `Mail::assertSent(VerifyUserEmail::class, 1)`), and the code diff shows the corresponding implementation changes that satisfy those assertions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d74031dd883268fbc89a07e4d07f3)