### PR TITLE
fix: sanitize editor guidance before save to prevent stored XSS

### DIFF
--- a/app/Panel/ScheduledConference/Livewire/EditorGuidance.php
+++ b/app/Panel/ScheduledConference/Livewire/EditorGuidance.php
@@ -11,6 +11,7 @@ use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Forms\Form;
 use Livewire\Component;
+use Stevebauman\Purify\Facades\Purify;
 
 class EditorGuidance extends Component implements HasForms
 {
@@ -43,7 +44,8 @@ class EditorGuidance extends Component implements HasForms
                         TinyEditor::make('meta.editor_guidelines')
                             ->label(__('general.editor_guidelines'))
                             ->plugins('autoresize link wordcount image code lists')
-                            ->toolbar('bold italic superscript subscript | link | blockquote bullist numlist'),
+                            ->toolbar('bold italic superscript subscript | link | blockquote bullist numlist')
+                            ->dehydrateStateUsing(fn (?string $state) => Purify::clean($state)),
                     ]),
                 Actions::make([
                     Action::make('save')


### PR DESCRIPTION
### Motivation
- Prevent stored XSS where rich-text `meta.editor_guidelines` was saved unsanitized and later rendered as raw HTML in the submission guidance modal.

### Description
- Import `Purify` and add `->dehydrateStateUsing(fn (?string $state) => Purify::clean($state))` to the `TinyEditor::make('meta.editor_guidelines')` field so guidance HTML is sanitized before persistence while preserving rich-text input.

### Testing
- `php -l app/Panel/ScheduledConference/Livewire/EditorGuidance.php` reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d745c5614832684000f367a43d040)