### PR TITLE
Restrict Role global scope in scheduled-conference context to prevent privilege escalation

### DIFF
--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -42,9 +42,10 @@ class Role extends Model
             });
 
             $builder->where(function (Builder $query) use ($scheduledConferenceScopeColumn, $scheduledConferenceId) {
-                $query->where($scheduledConferenceScopeColumn, 0);
                 if ($scheduledConferenceId) {
-                    $query->orWhere($scheduledConferenceScopeColumn, $scheduledConferenceId);
+                    $query->where($scheduledConferenceScopeColumn, $scheduledConferenceId);
+                } else {
+                    $query->where($scheduledConferenceScopeColumn, 0);
                 }
             });
         });


### PR DESCRIPTION
### Motivation
- Fix a privilege-escalation bug where scheduled-conference queries could include conference-level roles (`scheduled_conference_id = 0`), enabling scheduled editors to assign high-privilege conference roles such as Conference Manager.

### Description
- Update the `conferences` global scope in `app/Models/Role.php` to require `scheduled_conference_id = currentScheduledConferenceId` when a scheduled conference context exists, and only fall back to `scheduled_conference_id = 0` when no scheduled context is active.

### Testing
- Ran `php -l app/Models/Role.php` which reported no syntax errors (succeeded).
- Inspected `git diff -- app/Models/Role.php` to confirm the change is limited to the scheduled-conference scope logic (succeeded).
- Ran `git status --short` to verify the working tree state after the change (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d75a931ac832691d18eafc4fa5ec0)