### PR TITLE
Enforce RolePolicy checks for user role table and roles tab

### DIFF
--- a/app/Panel/Conference/Livewire/UserRoleTable.php
+++ b/app/Panel/Conference/Livewire/UserRoleTable.php
@@ -20,11 +20,18 @@ use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Component;
 
 class UserRoleTable extends Component implements HasForms, HasTable
 {
+    use AuthorizesRequests;
     use InteractsWithForms, InteractsWithTable;
+
+    public function mount(): void
+    {
+        $this->authorize('viewAny', Role::class);
+    }
 
     public function render()
     {
@@ -91,6 +98,7 @@ class UserRoleTable extends Component implements HasForms, HasTable
                             ->disabled(true),
                     ])
                     ->action(function (Role $record, array $data) {
+                        $this->authorize('update', $record);
                         $meta = $data['meta'] ?? [];
                         $meta['permission_level'] = $meta['permission_level'] ?? $record->getMeta('permission_level') ?? $record->name;
 
@@ -104,6 +112,7 @@ class UserRoleTable extends Component implements HasForms, HasTable
                     ->label(__('general.delete'))
                     ->requiresConfirmation()
                     ->action(function (Role $record) {
+                        $this->authorize('delete', $record);
                         if ($record->users_count > 0) {
                             Notification::make()
                                 ->title(__('general.failed'))
@@ -132,6 +141,7 @@ class UserRoleTable extends Component implements HasForms, HasTable
                             ->required(),
                     ])
                     ->action(function (array $data) {
+                        $this->authorize('create', Role::class);
                         RoleCreateAction::run([
                             'name' => $data['name'],
                             'meta' => $data['meta'],

--- a/resources/views/panel/conference/resources/user-resource/pages/list-users.blade.php
+++ b/resources/views/panel/conference/resources/user-resource/pages/list-users.blade.php
@@ -12,9 +12,11 @@
                 <x-filament::tabs.item alpine-active="activeTab === 'users-table'" x-on:click="activeTab = 'users-table'">
                     {{ __('general.users') }}
                 </x-filament::tabs.item>
-                <x-filament::tabs.item alpine-active="activeTab === 'role'" x-on:click="activeTab = 'role'">
-                    {{ __('general.roles') }}
-                </x-filament::tabs.item>
+                @can('viewAny', App\Models\Role::class)
+                    <x-filament::tabs.item alpine-active="activeTab === 'role'" x-on:click="activeTab = 'role'">
+                        {{ __('general.roles') }}
+                    </x-filament::tabs.item>
+                @endcan
                 <x-filament::tabs.item alpine-active="activeTab === 'notify-form'" x-on:click="activeTab = 'notify-form'">
                     {{ __('general.notify') }}
                 </x-filament::tabs.item>
@@ -50,9 +52,11 @@
                 {{ $this->table }}
                 {{ \Filament\Support\Facades\FilamentView::renderHook('panels::resource.pages.list-records.table.after', scopes: $this->getRenderHookScopes()) }}
             </div>
-            <div x-show="activeTab === 'role'">
-                @livewire(App\Panel\Conference\Livewire\UserRoleTable::class, ['lazy' => true])
-            </div>
+            @can('viewAny', App\Models\Role::class)
+                <div x-show="activeTab === 'role'">
+                    @livewire(App\Panel\Conference\Livewire\UserRoleTable::class, ['lazy' => true])
+                </div>
+            @endcan
             <div x-show="activeTab === 'notify-form'" style="display: none;">
                 <x-filament::section>
                     <x-slot name="heading">


### PR DESCRIPTION
### Motivation
- A newly added roles tab and `UserRoleTable` exposed role management UI and actions without invoking `RolePolicy` checks, allowing delegated users with `User:viewAny` but without `Role:*` privileges to list and mutate roles.
- The intent is to ensure role viewing, creation, update, and deletion require the existing `RolePolicy` permissions rather than relying on UI-only hiding.

### Description
- Add `AuthorizesRequests` to `UserRoleTable` and call `$this->authorize('viewAny', Role::class)` in `mount()` to enforce `RolePolicy::viewAny` before the table is available.
- Add explicit authorization checks in the component actions by calling `$this->authorize('create', Role::class)`, `$this->authorize('update', $record)`, and `$this->authorize('delete', $record)` before invoking role mutations.
- Wrap the Roles tab and the Livewire mount in the Blade view with `@can('viewAny', App\Models\Role::class)` so the tab and component are only rendered for authorized users as defense in depth.

### Testing
- Ran `php -l app/Panel/Conference/Livewire/UserRoleTable.php` and it reported no syntax errors.
- Performed a syntax check on `app/Policies/RolePolicy.php` with `php -l` (silently) and a Blade presence check was skipped due to tooling; no unit or integration tests were executed in this environment.
- The change is minimal and focused on adding authorization gates, preserving existing functionality for authorized users while preventing unauthorized role management.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d71c75f1083268170a32b74f3a5d5)