### PR TITLE
fix: restore ListUsers mount authorization in conference user list

### DIFF
--- a/app/Panel/Conference/Resources/UserResource/Pages/ListUsers.php
+++ b/app/Panel/Conference/Resources/UserResource/Pages/ListUsers.php
@@ -30,6 +30,8 @@ class ListUsers extends ListRecords implements HasForms
 
     public function mount(): void
     {
+        parent::mount();
+
         $this->notifyForm->fill();
     }
 


### PR DESCRIPTION
### Motivation
- Prevent a Filament authorization bypass where `ListUsers::mount()` previously omitted the parent lifecycle, allowing unauthorized access to the user list and the `sendNotification()` action.

### Description
- Inserted `parent::mount();` at the start of `ListUsers::mount()` in `app/Panel/Conference/Resources/UserResource/Pages/ListUsers.php` and retained the existing `$this->notifyForm->fill();` call so form initialization behavior is preserved.

### Testing
- Ran a syntax check with `php -l app/Panel/Conference/Resources/UserResource/Pages/ListUsers.php` which succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d7cf146588326b5f1d087ccb5ab05)