### PR TITLE
Fix invitation register login bypass for existing users

### DIFF
--- a/app/Frontend/Website/Pages/InvitationRegister.php
+++ b/app/Frontend/Website/Pages/InvitationRegister.php
@@ -37,6 +37,16 @@ class InvitationRegister extends Page
 
             return;
         }
+
+        $invitedUserExists = User::query()
+            ->whereRaw('LOWER(email) = ?', [mb_strtolower($invitation->email)])
+            ->exists();
+
+        if ($invitedUserExists) {
+            $this->redirect($this->getLoginUrl($invitation), navigate: false);
+
+            return;
+        }
     }
 
     public function getTitle(): string|Htmlable
@@ -74,14 +84,7 @@ class InvitationRegister extends Page
             ->first();
 
         if ($existingUser) {
-            $this->markInvitationEmailAsVerified($existingUser);
-
-            Filament::auth()->login($existingUser);
-            session()->regenerate();
-
-            AcceptUserInvitationAction::run($invitation, $existingUser);
-
-            return $this->redirect($this->getSuccessUrl($invitation), navigate: false);
+            return $this->redirect($this->getLoginUrl($invitation), navigate: false);
         }
 
         $user = UserCreateAction::run([
@@ -141,6 +144,24 @@ class InvitationRegister extends Page
             ->with(['conference', 'scheduledConference'])
             ->where('token', $token)
             ->firstOrFail();
+    }
+
+    protected function getLoginUrl(UserInvitation $invitation): string
+    {
+        if ($invitation->scheduledConference && $invitation->conference) {
+            return route('livewirePageGroup.scheduledConference.pages.login', [
+                'conference' => $invitation->conference->path,
+                'serie' => $invitation->scheduledConference->path,
+            ]);
+        }
+
+        if ($invitation->conference) {
+            return route('livewirePageGroup.conference.pages.login', [
+                'conference' => $invitation->conference->path,
+            ]);
+        }
+
+        return route('livewirePageGroup.website.pages.login');
     }
 
     protected function getSuccessUrl(UserInvitation $invitation): string


### PR DESCRIPTION
### Motivation

- The public `/invitations/{token}/register` route allowed an attacker who possessed an invitation token to log in as an existing invited user without proving account ownership, creating a token-based authentication bypass.

### Description

- In `InvitationRegister::mount()` the code now detects when the invitation email already belongs to an existing account and redirects unauthenticated visitors to the appropriate scoped login page instead of allowing registration.
- The insecure auto-login branch was removed from `InvitationRegister::register()` so existing users are no longer authenticated solely by presenting an invitation token and must perform a normal login before accepting the invitation.
- Added a `getLoginUrl()` helper to compute the correct login URL for website/conference/scheduled-conference contexts and centralize redirect behavior.

### Testing

- Ran `php -l app/Frontend/Website/Pages/InvitationRegister.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d793710a88326a2a8fa8321e9c0b1)