### PR TITLE
Enforce final-only access on presentation detail page to prevent IDOR

### DIFF
--- a/app/Panel/ScheduledConference/Pages/PresentationDetail.php
+++ b/app/Panel/ScheduledConference/Pages/PresentationDetail.php
@@ -8,6 +8,7 @@ use Filament\Forms\Contracts\HasForms;
 use Filament\Pages\Page;
 use Illuminate\Contracts\Support\Htmlable;
 use Livewire\Attributes\Renderless;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class PresentationDetail extends Page implements HasForms
 {
@@ -27,6 +28,10 @@ class PresentationDetail extends Page implements HasForms
 
     public function mount(): void
     {
+        if (! $this->record->is_final) {
+            throw new NotFoundHttpException;
+        }
+
         $this->record->load(['submission' => ['authors.role', 'meta']]);
         $this->record->registerView((int) auth()->id());
     }


### PR DESCRIPTION
### Motivation
- The presentation detail page exposed non-final presentations via `/presentations/{record}` without checking `is_final`, allowing authenticated users to view unpublished content and interact with discussions without the intended visibility boundary.

### Description
- Add a server-side guard in `PresentationDetail::mount()` that throws `NotFoundHttpException` when `$record->is_final` is false and import `NotFoundHttpException`, preserving relation loading and view registration for final presentations.

### Testing
- Ran `php -l app/Panel/ScheduledConference/Pages/PresentationDetail.php`, which passed with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d788b645083268da3f4275f4849a2)