### PR TITLE
fix: deny unauthorized conference-panel access when no published schedule

### DIFF
--- a/app/Http/Middleware/RedirectPanelIfCannotAccess.php
+++ b/app/Http/Middleware/RedirectPanelIfCannotAccess.php
@@ -32,9 +32,11 @@ class RedirectPanelIfCannotAccess
             if ($user->can('view', $conference)) {
                 return $next($request);
             }
-            if($conference->currentScheduledConference){
+            if ($conference->currentScheduledConference) {
                 return redirect()->to($conference->currentScheduledConference->getPanelUrl());
             }
+
+            abort(403);
         }
 
         return $next($request);


### PR DESCRIPTION
### Motivation
- The middleware `RedirectPanelIfCannotAccess` could fall through to `$next($request)` when a user was not authorized to `view` the conference but the `currentScheduledConference` relation was null, allowing unauthorised access to conference panel pages.

### Description
- Add an explicit `abort(403);` in `app/Http/Middleware/RedirectPanelIfCannotAccess.php` so unauthorized users without a `currentScheduledConference` are denied while preserving the existing redirect for conferences that do have a scheduled conference and the authorized path.

### Testing
- Ran `php -l app/Http/Middleware/RedirectPanelIfCannotAccess.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d800bd09483268bb95e3c46d28b4e)