### PR TITLE
fix: prevent self-edit route resolution in UserResource

### DIFF
--- a/app/Panel/Conference/Resources/UserResource.php
+++ b/app/Panel/Conference/Resources/UserResource.php
@@ -67,6 +67,7 @@ class UserResource extends Resource
     {
         return static::getModel()::query()
             ->with(['meta', 'media', 'bans'])
+            ->where('id', '!=', auth()->id())
             ->when(!app()->isOnSite(), fn(Builder $query) => $query->whereHas('roles', fn($query) => $query->where('name', '!=', UserRole::Admin)));
     }
 


### PR DESCRIPTION
### Motivation
- Prevent a privilege-escalation path where authenticated low-privilege users could resolve and edit their own `User` record via the shared conference/scheduled-conference `UserResource`, then submit arbitrary non-Admin role IDs to `syncRoles()`.

### Description
- Restore the prior self-exclusion in `UserResource::getEloquentQuery()` by adding `->where('id', '!=', auth()->id())` so the current user record cannot be resolved by the resource edit route.

### Testing
- Ran a syntax check with `php -l app/Panel/Conference/Resources/UserResource.php` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0da3870ed88326824fe62e050f8742)