### PR TITLE
fix: restrict upgrade runner to authenticated admins

### DIFF
--- a/app/Frontend/Website/Pages/Upgrade.php
+++ b/app/Frontend/Website/Pages/Upgrade.php
@@ -7,6 +7,7 @@ use App\Facades\MetaTag;
 use App\Http\Middleware\RedirectToConference;
 use App\Http\Middleware\SetLocale;
 use App\Http\Middleware\SetupDefaultData;
+use App\Models\Enums\UserRole;
 
 class Upgrade extends Page
 {
@@ -21,6 +22,8 @@ class Upgrade extends Page
     public function mount()
     {
         MetaTag::add('robots', 'noindex, nofollow');
+
+        abort_unless(auth()->check() && auth()->user()->hasRole(UserRole::Admin), 403);
 
         if (version_compare(app()->getInstalledVersion(), app()->getCodeVersion(), '>=')) {
             return redirect('/');
@@ -42,6 +45,8 @@ class Upgrade extends Page
 
     public function upgrade()
     {
+        abort_unless(auth()->check() && auth()->user()->hasRole(UserRole::Admin), 403);
+
         try {
             UpgradeAction::run();
 


### PR DESCRIPTION
### Motivation
- A version bump made deployed installations with an older database enter upgrade mode and exposed the public `Upgrade` Livewire page and action to unauthenticated visitors, allowing remote invocation of privileged upgrade routines. 
- The intended fix is to prevent unauthenticated or non-admin users from viewing or submitting the upgrade page so attackers cannot trigger cache clears, schema migrations, media moves, or version writes.

### Description
- Import `App\Models\Enums\UserRole` and add an explicit authorization guard in `mount()` to abort unless `auth()->check()` and the user `hasRole(UserRole::Admin)`, blocking non-admin page access. 
- Add the same `abort_unless(...)` guard at the start of `upgrade()` to prevent unauthenticated Livewire submissions from invoking `UpgradeAction::run()`.

### Testing
- Performed a PHP syntax check with `php -l app/Frontend/Website/Pages/Upgrade.php` and it returned `No syntax errors detected` (success). 
- No automated unit or integration tests were changed or executed for this small security fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0da6ea05888326b610955bec7fe2ca)