### PR TITLE
Allow Change Decision to show all valid stage decisions

### DIFF
--- a/app/Models/States/Submission/DeclinedSubmissionState.php
+++ b/app/Models/States/Submission/DeclinedSubmissionState.php
@@ -10,6 +10,11 @@ use App\Models\Enums\SubmissionStatus;
 
 class DeclinedSubmissionState extends BaseSubmissionState
 {
+    public function decline(): void
+    {
+        // Repeating the current decision is allowed so editors can resend its notification.
+    }
+
     public function acceptAbstract(): void
     {
         SubmissionUpdateAction::run([
@@ -22,6 +27,25 @@ class DeclinedSubmissionState extends BaseSubmissionState
             subject: $this->submission,
             description: __('general.submission_send_to_review'),
             event : 'submission-abstract-accepted',
+        )
+            ->by(auth()->user())
+            ->save();
+    }
+
+    public function acceptAndSkipReview(): void
+    {
+        SubmissionUpdateAction::run([
+            'skipped_review' => true,
+            'revision_required' => false,
+            'status' => SubmissionStatus::OnPresentation,
+            'stage' => SubmissionStage::Presentation,
+        ], $this->submission);
+
+        Log::make(
+            name: 'submission',
+            subject: $this->submission,
+            description: __('general.submission_accept_and_skip_review'),
+            event: 'submission-skip-review',
         )
             ->by(auth()->user())
             ->save();

--- a/app/Models/States/Submission/EditingSubmissionState.php
+++ b/app/Models/States/Submission/EditingSubmissionState.php
@@ -4,6 +4,7 @@ namespace App\Models\States\Submission;
 
 use App\Actions\Submissions\SubmissionUpdateAction;
 use App\Classes\Log;
+use App\Events\Submissions\Accepted;
 use App\Events\Submissions\Published;
 use App\Models\Enums\SubmissionStage;
 use App\Models\Enums\SubmissionStatus;
@@ -14,6 +15,70 @@ class EditingSubmissionState extends BaseSubmissionState
 {
     use CanDeclinePayment;
     use CanWithdraw;
+
+    public function sendToEditing(): void
+    {
+        // Repeating the current decision is allowed so editors can resend its notification.
+    }
+
+    public function acceptAbstract(): void
+    {
+        SubmissionUpdateAction::run([
+            'revision_required' => false,
+            'skipped_review' => false,
+            'stage' => SubmissionStage::PeerReview,
+            'status' => SubmissionStatus::OnReview,
+        ], $this->submission);
+
+        Log::make(
+            name: 'submission',
+            subject: $this->submission,
+            description: __('general.submission_send_to_review'),
+            event: 'submission-abstract-accepted',
+        )
+            ->by(auth()->user())
+            ->save();
+    }
+
+    public function acceptAndSkipReview(): void
+    {
+        SubmissionUpdateAction::run([
+            'skipped_review' => true,
+            'revision_required' => false,
+            'status' => SubmissionStatus::OnPresentation,
+            'stage' => SubmissionStage::Presentation,
+        ], $this->submission);
+
+        Log::make(
+            name: 'submission',
+            subject: $this->submission,
+            description: __('general.submission_accept_and_skip_review'),
+            event: 'submission-skip-review',
+        )
+            ->by(auth()->user())
+            ->save();
+    }
+
+    public function sendToPresentation(): void
+    {
+        SubmissionUpdateAction::run([
+            'revision_required' => false,
+            'skipped_review' => false,
+            'stage' => SubmissionStage::Presentation,
+            'status' => SubmissionStatus::OnPresentation,
+        ], $this->submission);
+
+        Accepted::dispatch($this->submission);
+
+        Log::make(
+            name: 'submission',
+            subject: $this->submission,
+            description: __('general.submission_send_to_presentation'),
+            event: 'submission-send-to-presentation',
+        )
+            ->by(auth()->user())
+            ->save();
+    }
 
     public function publish(): void
     {

--- a/app/Models/States/Submission/OnPresentationSubmissionState.php
+++ b/app/Models/States/Submission/OnPresentationSubmissionState.php
@@ -15,6 +15,49 @@ class OnPresentationSubmissionState extends BaseSubmissionState
     use CanDeclinePayment;
     use CanWithdraw;
 
+    public function sendToPresentation(): void
+    {
+        // Repeating the current decision is allowed so editors can resend its notification.
+    }
+
+    public function acceptAbstract(): void
+    {
+        SubmissionUpdateAction::run([
+            'revision_required' => false,
+            'skipped_review' => false,
+            'stage' => SubmissionStage::PeerReview,
+            'status' => SubmissionStatus::OnReview,
+        ], $this->submission);
+
+        Log::make(
+            name: 'submission',
+            subject: $this->submission,
+            description: __('general.submission_send_to_review'),
+            event: 'submission-abstract-accepted',
+        )
+            ->by(auth()->user())
+            ->save();
+    }
+
+    public function acceptAndSkipReview(): void
+    {
+        SubmissionUpdateAction::run([
+            'skipped_review' => true,
+            'revision_required' => false,
+            'status' => SubmissionStatus::OnPresentation,
+            'stage' => SubmissionStage::Presentation,
+        ], $this->submission);
+
+        Log::make(
+            name: 'submission',
+            subject: $this->submission,
+            description: __('general.submission_accept_and_skip_review'),
+            event: 'submission-skip-review',
+        )
+            ->by(auth()->user())
+            ->save();
+    }
+
     public function sendToEditing(): void
     {
         SubmissionUpdateAction::run([

--- a/app/Models/States/Submission/OnReviewSubmissionState.php
+++ b/app/Models/States/Submission/OnReviewSubmissionState.php
@@ -15,6 +15,30 @@ class OnReviewSubmissionState extends BaseSubmissionState
     use CanDeclinePayment;
     use CanWithdraw;
 
+    public function acceptAbstract(): void
+    {
+        // Repeating the current decision is allowed so editors can resend its notification.
+    }
+
+    public function acceptAndSkipReview(): void
+    {
+        SubmissionUpdateAction::run([
+            'skipped_review' => true,
+            'revision_required' => false,
+            'status' => SubmissionStatus::OnPresentation,
+            'stage' => SubmissionStage::Presentation,
+        ], $this->submission);
+
+        Log::make(
+            name: 'submission',
+            subject: $this->submission,
+            description: __('general.submission_accept_and_skip_review'),
+            event: 'submission-skip-review',
+        )
+            ->by(auth()->user())
+            ->save();
+    }
+
     public function sendToPresentation(): void
     {
         SubmissionUpdateAction::run([

--- a/app/Panel/ScheduledConference/Livewire/Submissions/PeerReview.php
+++ b/app/Panel/ScheduledConference/Livewire/Submissions/PeerReview.php
@@ -332,7 +332,12 @@ class PeerReview extends Component implements HasActions, HasForms
 
     public function render()
     {
-        if ($this->submission->status->isBefore(SubmissionStatus::OnReview)) {
+        if (! in_array($this->submission->stage, [
+            SubmissionStage::PeerReview,
+            SubmissionStage::Presentation,
+            SubmissionStage::Editing,
+            SubmissionStage::Proceeding,
+        ])) {
             return view('panel.scheduledConference.livewire.submissions.message', ['message' => 'Stage not initiated']);
         }
 

--- a/app/Panel/ScheduledConference/Livewire/Submissions/Presentation.php
+++ b/app/Panel/ScheduledConference/Livewire/Submissions/Presentation.php
@@ -2,6 +2,7 @@
 
 namespace App\Panel\ScheduledConference\Livewire\Submissions;
 
+use App\Models\Enums\SubmissionStage;
 use App\Models\Enums\SubmissionStatus;
 use App\Models\Submission;
 use App\Panel\ScheduledConference\Resources\SubmissionResource;
@@ -59,7 +60,11 @@ class Presentation extends Component implements HasActions, HasForms
 
     public function render()
     {
-        if ($this->submission->status->isBefore(SubmissionStatus::OnPresentation)) {
+        if (! in_array($this->submission->stage, [
+            SubmissionStage::Presentation,
+            SubmissionStage::Editing,
+            SubmissionStage::Proceeding,
+        ])) {
             return view('panel.scheduledConference.livewire.submissions.message', ['message' => 'Stage not initiated']);
         }
 

--- a/app/Policies/SubmissionPolicy.php
+++ b/app/Policies/SubmissionPolicy.php
@@ -53,7 +53,7 @@ class SubmissionPolicy
     public function delete(User $user, Submission $submission)
     {
         // Only submission with status: withdrawn or declined can be deleted.
-        if (!in_array($submission->status, [SubmissionStatus::Declined, SubmissionStatus::Withdrawn, SubmissionStatus::Incomplete])) {
+        if (! in_array($submission->status, [SubmissionStatus::Declined, SubmissionStatus::Withdrawn, SubmissionStatus::Incomplete])) {
             return false;
         }
 
@@ -115,7 +115,15 @@ class SubmissionPolicy
 
     public function declinePaper(User $user, Submission $submission)
     {
-        if (in_array($submission->status, [SubmissionStatus::Withdrawn, SubmissionStatus::Declined, SubmissionStatus::Published, SubmissionStatus::OnPayment, SubmissionStatus::PaymentDeclined, SubmissionStatus::Queued, SubmissionStatus::Declined])) {
+        if ($submission->status === SubmissionStatus::Declined) {
+            return in_array($submission->stage, [
+                SubmissionStage::PeerReview,
+                SubmissionStage::Presentation,
+                SubmissionStage::Editing,
+            ]) && $user->can('actAsEditor', $submission);
+        }
+
+        if (in_array($submission->status, [SubmissionStatus::Withdrawn, SubmissionStatus::Published, SubmissionStatus::OnPayment, SubmissionStatus::PaymentDeclined, SubmissionStatus::Queued])) {
             return false;
         }
 
@@ -136,7 +144,7 @@ class SubmissionPolicy
             return true;
         }
 
-        if (!$submission->isParticipant($user)) {
+        if (! $submission->isParticipant($user)) {
             return false;
         }
 
@@ -198,7 +206,19 @@ class SubmissionPolicy
 
     public function acceptPaper(User $user, Submission $submission)
     {
-        if (in_array($submission->status, [SubmissionStatus::Withdrawn, SubmissionStatus::Declined, SubmissionStatus::Published, SubmissionStatus::OnPresentation, SubmissionStatus::OnPayment, SubmissionStatus::PaymentDeclined, SubmissionStatus::Queued])) {
+        if ($submission->status === SubmissionStatus::Declined) {
+            return in_array($submission->stage, [
+                SubmissionStage::PeerReview,
+                SubmissionStage::Presentation,
+            ]) && $user->can('actAsEditor', $submission);
+        }
+
+        if ($submission->status === SubmissionStatus::OnPresentation) {
+            return $submission->stage === SubmissionStage::Presentation
+                && $user->can('actAsEditor', $submission);
+        }
+
+        if (in_array($submission->status, [SubmissionStatus::Withdrawn, SubmissionStatus::Published, SubmissionStatus::OnPayment, SubmissionStatus::PaymentDeclined, SubmissionStatus::Queued])) {
             return false;
         }
 
@@ -230,7 +250,7 @@ class SubmissionPolicy
             return false;
         }
 
-        if (!$submission->registration) {
+        if (! $submission->registration) {
             return false;
         }
 
@@ -241,11 +261,11 @@ class SubmissionPolicy
 
     public function review(User $user, Submission $submission)
     {
-        if (!in_array($submission->stage, [SubmissionStage::PeerReview, SubmissionStage::Presentation, SubmissionStage::Editing, SubmissionStage::Proceeding])) {
+        if (! in_array($submission->stage, [SubmissionStage::PeerReview, SubmissionStage::Presentation, SubmissionStage::Editing, SubmissionStage::Proceeding])) {
             return false;
         }
 
-        if (!$submission->reviews->where('user_id', $user->getKey())->first()) {
+        if (! $submission->reviews->where('user_id', $user->getKey())->first()) {
             return false;
         }
 
@@ -256,7 +276,12 @@ class SubmissionPolicy
 
     public function requestRevision(User $user, Submission $submission)
     {
-        if (in_array($submission->status, [SubmissionStatus::Withdrawn, SubmissionStatus::Declined, SubmissionStatus::Published, SubmissionStatus::OnPayment, SubmissionStatus::PaymentDeclined, SubmissionStatus::Queued])) {
+        if ($submission->status === SubmissionStatus::Declined) {
+            return $submission->stage === SubmissionStage::PeerReview
+                && $user->can('actAsEditor', $submission);
+        }
+
+        if (in_array($submission->status, [SubmissionStatus::Withdrawn, SubmissionStatus::Published, SubmissionStatus::OnPayment, SubmissionStatus::PaymentDeclined, SubmissionStatus::Queued])) {
             return false;
         }
 
@@ -274,7 +299,11 @@ class SubmissionPolicy
 
     public function sendToEditing(User $user, Submission $submission)
     {
-        if ($submission->stage != SubmissionStage::Presentation) {
+        if (in_array($submission->status, [SubmissionStatus::Withdrawn, SubmissionStatus::Published, SubmissionStatus::OnPayment, SubmissionStatus::PaymentDeclined, SubmissionStatus::Queued])) {
+            return false;
+        }
+
+        if (! in_array($submission->stage, [SubmissionStage::Presentation, SubmissionStage::Editing])) {
             return false;
         }
 
@@ -308,7 +337,7 @@ class SubmissionPolicy
         }
 
         // Editors cannot withdraw submissions; they must wait for the author to request it..
-        if (!filled($submission->withdrawn_reason)) {
+        if (! filled($submission->withdrawn_reason)) {
             return false;
         }
 
@@ -405,7 +434,7 @@ class SubmissionPolicy
     public function preview(User $user, Submission $submission)
     {
         $editorIds = $submission->participants()
-            ->whereHas('role', fn(Builder $query) => $query->withoutGlobalScopes()->whereIn('name', [UserRole::ScheduledConferenceEditor, UserRole::TrackEditor]))
+            ->whereHas('role', fn (Builder $query) => $query->withoutGlobalScopes()->whereIn('name', [UserRole::ScheduledConferenceEditor, UserRole::TrackEditor]))
             ->pluck('user_id');
 
         if (in_array($user->getKey(), $editorIds->toArray())) {
@@ -428,7 +457,7 @@ class SubmissionPolicy
 
     public function actAsEditor(User $user, Submission $submission)
     {
-        if ($user->can('submitAs', Submission::class) && !$submission->isParticipantAuthor($user)) {
+        if ($user->can('submitAs', Submission::class) && ! $submission->isParticipantAuthor($user)) {
             return true;
         }
 

--- a/resources/views/panel/scheduledConference/livewire/submissions/call-for-abstract.blade.php
+++ b/resources/views/panel/scheduledConference/livewire/submissions/call-for-abstract.blade.php
@@ -25,7 +25,12 @@
                 </div>
             @endif
 
-            @if($submission->status !== SubmissionStatus::Published)
+            @if(! in_array($submission->status, [
+                SubmissionStatus::Published,
+                SubmissionStatus::Withdrawn,
+                SubmissionStatus::OnPayment,
+                SubmissionStatus::PaymentDeclined,
+            ]))
                 <div x-data="{ decision:@js($submissionDecision) }" class="space-y-4">
                     @if($submissionDecision)
                         <div class="px-6 py-5 space-y-3 overflow-hidden bg-white shadow-sm rounded-xl ring-1 ring-gray-950/5 dark:ring-white/10">
@@ -41,13 +46,9 @@
                     <div @class([
                         'space-y-4',
                     ]) x-show="!decision">
-                        @if (!in_array($this->submission->status, [SubmissionStatus::OnPayment, SubmissionStatus::OnReview, SubmissionStatus::PaymentDeclined, SubmissionStatus::Editing, SubmissionStatus::OnPresentation]))
-                            {{ $this->acceptAction() }}
-                            {{ $this->acceptAndSkipReview() }}
-                        @endif
-                        @if (!in_array($this->submission->status, [SubmissionStatus::Declined]))
-                            {{ $this->declineAction() }}
-                        @endif
+                        {{ $this->acceptAction() }}
+                        {{ $this->acceptAndSkipReview() }}
+                        {{ $this->declineAction() }}
                     </div>
                     @endif
                 </div>

--- a/resources/views/panel/scheduledConference/livewire/submissions/peer-review.blade.php
+++ b/resources/views/panel/scheduledConference/livewire/submissions/peer-review.blade.php
@@ -67,6 +67,7 @@
                         'hidden' => in_array($submission->status, [
                             SubmissionStatus::Queued, 
                             SubmissionStatus::Published,
+                            SubmissionStatus::Withdrawn,
                             SubmissionStatus::OnPayment,
                             SubmissionStatus::PaymentDeclined,
                         ]),
@@ -74,10 +75,10 @@
                         @if ($user->can('requestRevision', $submission))
                             {{ $this->requestRevisionAction() }}
                         @endif
-                        @if ($user->can('acceptPaper', $submission) && ($submission->status != SubmissionStatus::Editing || $submission->skipped_review))
+                        @if ($user->can('acceptPaper', $submission))
                             {{ $this->acceptSubmissionAction() }}
                         @endif
-                        @if ($user->can('declinePaper', $submission) && ! in_array($submission->status, [SubmissionStatus::Declined]))
+                        @if ($user->can('declinePaper', $submission))
                             {{ $this->declineSubmissionAction() }}
                         @endif
                     </div>

--- a/resources/views/panel/scheduledConference/livewire/submissions/presentation.blade.php
+++ b/resources/views/panel/scheduledConference/livewire/submissions/presentation.blade.php
@@ -32,6 +32,9 @@
                         <div class="text-base">
                             {{ __('general.submission_send_to_editing') }}
                         </div>
+                        <button class="text-sm underline text-primary-500"
+                            @@click="decision = !decision" x-text="decision ? 'Change Decision' : 'Cancel'"
+                        ></button>
                     </div>
                 @endif
 
@@ -41,6 +44,7 @@
                         SubmissionStatus::Queued,
                         SubmissionStatus::OnPayment,
                         SubmissionStatus::Published,
+                        SubmissionStatus::Withdrawn,
                         SubmissionStatus::PaymentDeclined,
                     ]),
                 ]) x-show="!decision">

--- a/tests/Feature/SubmissionDecisionActionsTest.php
+++ b/tests/Feature/SubmissionDecisionActionsTest.php
@@ -1,0 +1,367 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Conference;
+use App\Models\Enums\SubmissionStage;
+use App\Models\Enums\SubmissionStatus;
+use App\Models\Enums\UserRole;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\ScheduledConference;
+use App\Models\Submission;
+use App\Models\Track;
+use App\Models\User;
+use App\Panel\ScheduledConference\Livewire\Submissions\CallforAbstract;
+use App\Panel\ScheduledConference\Livewire\Submissions\PeerReview;
+use App\Panel\ScheduledConference\Livewire\Submissions\Presentation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Route;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class SubmissionDecisionActionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Route::get('/test/submissions/{record}', fn () => null)
+            ->name('filament.conference.resources.submissions.view');
+
+        Route::get('/test/submissions/{record}/review', fn () => null)
+            ->name('filament.conference.resources.submissions.review');
+    }
+
+    public function test_call_for_abstract_change_decision_shows_the_current_review_decision(): void
+    {
+        $context = $this->makeEditorSubmissionContext([
+            'stage' => SubmissionStage::PeerReview,
+            'status' => SubmissionStatus::OnReview,
+        ]);
+
+        $this->actingAs($context['editor']);
+
+        Livewire::test(CallforAbstract::class, ['submission' => $context['submission']])
+            ->assertSee(__('general.send_for_review'))
+            ->assertSee(__('general.skip_review'))
+            ->assertSee(__('general.decline'));
+    }
+
+    public function test_call_for_abstract_change_decision_shows_all_decisions_after_skipping_to_presentation(): void
+    {
+        $context = $this->makeEditorSubmissionContext([
+            'stage' => SubmissionStage::Presentation,
+            'status' => SubmissionStatus::OnPresentation,
+        ]);
+
+        $this->actingAs($context['editor']);
+
+        Livewire::test(CallforAbstract::class, ['submission' => $context['submission']])
+            ->assertSee(__('general.send_for_review'))
+            ->assertSee(__('general.skip_review'))
+            ->assertSee(__('general.decline'));
+    }
+
+    public function test_call_for_abstract_change_decision_shows_all_decisions_after_sending_to_editing(): void
+    {
+        $context = $this->makeEditorSubmissionContext([
+            'stage' => SubmissionStage::Editing,
+            'status' => SubmissionStatus::Editing,
+        ]);
+
+        $this->actingAs($context['editor']);
+
+        Livewire::test(CallforAbstract::class, ['submission' => $context['submission']])
+            ->assertSee(__('general.send_for_review'))
+            ->assertSee(__('general.skip_review'))
+            ->assertSee(__('general.decline'));
+    }
+
+    public function test_call_for_abstract_change_decision_shows_the_current_decline_decision(): void
+    {
+        $context = $this->makeEditorSubmissionContext([
+            'stage' => SubmissionStage::CallforAbstract,
+            'status' => SubmissionStatus::Declined,
+        ]);
+
+        $this->actingAs($context['editor']);
+
+        Livewire::test(CallforAbstract::class, ['submission' => $context['submission']])
+            ->assertSee(__('general.send_for_review'))
+            ->assertSee(__('general.skip_review'))
+            ->assertSee(__('general.decline'));
+    }
+
+    public function test_peer_review_change_decision_shows_the_current_accept_decision(): void
+    {
+        $context = $this->makeEditorSubmissionContext([
+            'stage' => SubmissionStage::Presentation,
+            'status' => SubmissionStatus::OnPresentation,
+        ]);
+
+        $this->actingAs($context['editor']);
+
+        Livewire::test(PeerReview::class, ['submission' => $context['submission']])
+            ->assertSee(__('general.request_revision'))
+            ->assertSee(__('general.accept_submission'))
+            ->assertSee(__('general.decline_submission'));
+    }
+
+    public function test_peer_review_change_decision_shows_the_current_decline_decision(): void
+    {
+        $context = $this->makeEditorSubmissionContext([
+            'stage' => SubmissionStage::PeerReview,
+            'status' => SubmissionStatus::Declined,
+        ]);
+
+        $this->actingAs($context['editor']);
+
+        Livewire::test(PeerReview::class, ['submission' => $context['submission']])
+            ->assertSee(__('general.request_revision'))
+            ->assertSee(__('general.accept_submission'))
+            ->assertSee(__('general.decline_submission'));
+    }
+
+    public function test_peer_review_change_decision_shows_all_decisions_after_sending_to_editing(): void
+    {
+        $context = $this->makeEditorSubmissionContext([
+            'stage' => SubmissionStage::Editing,
+            'status' => SubmissionStatus::Editing,
+        ]);
+
+        $this->actingAs($context['editor']);
+
+        Livewire::test(PeerReview::class, ['submission' => $context['submission']])
+            ->assertSee(__('general.request_revision'))
+            ->assertSee(__('general.accept_submission'))
+            ->assertSee(__('general.decline_submission'));
+    }
+
+    public function test_presentation_change_decision_shows_the_current_editing_decision(): void
+    {
+        $context = $this->makeEditorSubmissionContext([
+            'stage' => SubmissionStage::Editing,
+            'status' => SubmissionStatus::Editing,
+        ]);
+
+        $this->actingAs($context['editor']);
+
+        Livewire::test(Presentation::class, ['submission' => $context['submission']])
+            ->assertSee(__('general.send_to_editing'));
+    }
+
+    public function test_presentation_change_decision_shows_editing_decision_after_decline_at_presentation_stage(): void
+    {
+        $context = $this->makeEditorSubmissionContext([
+            'stage' => SubmissionStage::Presentation,
+            'status' => SubmissionStatus::Declined,
+        ]);
+
+        $this->actingAs($context['editor']);
+
+        Livewire::test(Presentation::class, ['submission' => $context['submission']])
+            ->assertSee(__('general.send_to_editing'));
+    }
+
+    public function test_call_for_abstract_decision_can_move_editing_submission_back_to_review(): void
+    {
+        Mail::fake();
+
+        $context = $this->makeEditorSubmissionContext([
+            'stage' => SubmissionStage::Editing,
+            'status' => SubmissionStatus::Editing,
+        ]);
+
+        $this->actingAs($context['editor']);
+
+        Livewire::test(CallforAbstract::class, ['submission' => $context['submission']])
+            ->callAction('accept', data: $this->callForAbstractNotificationData([
+                'papers' => [],
+            ]));
+
+        $context['submission']->refresh();
+
+        $this->assertSame(SubmissionStage::PeerReview, $context['submission']->stage);
+        $this->assertSame(SubmissionStatus::OnReview, $context['submission']->status);
+    }
+
+    public function test_call_for_abstract_decision_can_skip_editing_submission_to_presentation(): void
+    {
+        Mail::fake();
+
+        $context = $this->makeEditorSubmissionContext([
+            'stage' => SubmissionStage::Editing,
+            'status' => SubmissionStatus::Editing,
+        ]);
+
+        $this->actingAs($context['editor']);
+
+        Livewire::test(CallforAbstract::class, ['submission' => $context['submission']])
+            ->callAction('acceptAndSkipReview', data: $this->paperNotificationData());
+
+        $context['submission']->refresh();
+
+        $this->assertSame(SubmissionStage::Presentation, $context['submission']->stage);
+        $this->assertSame(SubmissionStatus::OnPresentation, $context['submission']->status);
+        $this->assertTrue($context['submission']->skipped_review);
+    }
+
+    public function test_peer_review_decision_can_request_revision_from_presentation(): void
+    {
+        Mail::fake();
+
+        $context = $this->makeEditorSubmissionContext([
+            'stage' => SubmissionStage::Presentation,
+            'status' => SubmissionStatus::OnPresentation,
+        ]);
+
+        $this->actingAs($context['editor']);
+
+        Livewire::test(PeerReview::class, ['submission' => $context['submission']])
+            ->callAction('requestRevisionAction', data: $this->paperNotificationData());
+
+        $context['submission']->refresh();
+
+        $this->assertSame(SubmissionStage::PeerReview, $context['submission']->stage);
+        $this->assertSame(SubmissionStatus::OnReview, $context['submission']->status);
+        $this->assertTrue($context['submission']->revision_required);
+    }
+
+    public function test_peer_review_decision_can_move_editing_submission_back_to_presentation(): void
+    {
+        Mail::fake();
+
+        $context = $this->makeEditorSubmissionContext([
+            'stage' => SubmissionStage::Editing,
+            'status' => SubmissionStatus::Editing,
+        ]);
+
+        $this->actingAs($context['editor']);
+
+        Livewire::test(PeerReview::class, ['submission' => $context['submission']])
+            ->callAction('acceptSubmissionAction', data: $this->paperNotificationData());
+
+        $context['submission']->refresh();
+
+        $this->assertSame(SubmissionStage::Presentation, $context['submission']->stage);
+        $this->assertSame(SubmissionStatus::OnPresentation, $context['submission']->status);
+    }
+
+    public function test_presentation_decision_can_move_declined_submission_to_editing(): void
+    {
+        $context = $this->makeEditorSubmissionContext([
+            'stage' => SubmissionStage::Presentation,
+            'status' => SubmissionStatus::Declined,
+        ]);
+
+        $this->actingAs($context['editor']);
+
+        Livewire::test(Presentation::class, ['submission' => $context['submission']])
+            ->callAction('sendToEditing');
+
+        $context['submission']->refresh();
+
+        $this->assertSame(SubmissionStage::Editing, $context['submission']->stage);
+        $this->assertSame(SubmissionStatus::Editing, $context['submission']->status);
+    }
+
+    protected function callForAbstractNotificationData(array $overrides = []): array
+    {
+        return [
+            'subject' => 'Decision update',
+            'message' => 'Decision update message',
+            'no-notification' => true,
+            ...$overrides,
+        ];
+    }
+
+    protected function paperNotificationData(array $overrides = []): array
+    {
+        return [
+            'email' => 'author@example.test',
+            'subject' => 'Decision update',
+            'message' => 'Decision update message',
+            'do-not-notify-author' => true,
+            ...$overrides,
+        ];
+    }
+
+    protected function makeEditorSubmissionContext(array $submissionState): array
+    {
+        $conference = Conference::query()->create([
+            'name' => 'Conference',
+            'path' => 'conference',
+        ]);
+
+        $scheduledConference = ScheduledConference::withoutGlobalScopes()->create([
+            'conference_id' => $conference->getKey(),
+            'title' => 'Scheduled Conference',
+            'path' => 'scheduled-conference',
+            'date_start' => now()->toDateString(),
+            'date_end' => now()->addDays(2)->toDateString(),
+        ]);
+
+        app()->setCurrentConferenceId($conference->getKey());
+        app()->setCurrentScheduledConferenceId($scheduledConference->getKey());
+
+        $track = Track::withoutGlobalScopes()->create([
+            'scheduled_conference_id' => $scheduledConference->getKey(),
+            'title' => 'Track',
+            'abbreviation' => 'TRK',
+            'is_active' => true,
+        ]);
+
+        $author = User::query()->create([
+            'given_name' => 'Author',
+            'family_name' => 'Tester',
+            'email' => 'author@example.test',
+            'password' => 'password123456',
+        ]);
+
+        $editor = User::query()->create([
+            'given_name' => 'Editor',
+            'family_name' => 'Tester',
+            'email' => 'editor@example.test',
+            'password' => 'password123456',
+        ]);
+
+        $editorRole = Role::withoutGlobalScopes()
+            ->where('name', UserRole::ScheduledConferenceEditor->value)
+            ->where('conference_id', $conference->getKey())
+            ->where('scheduled_conference_id', $scheduledConference->getKey())
+            ->firstOrFail();
+
+        Permission::query()->firstOrCreate([
+            'name' => 'Submission:sendToEditing',
+            'guard_name' => 'web',
+        ]);
+
+        $editor->assignRole($editorRole);
+
+        $submission = Submission::withoutGlobalScopes()->forceCreate([
+            'user_id' => $author->getKey(),
+            'conference_id' => $conference->getKey(),
+            'scheduled_conference_id' => $scheduledConference->getKey(),
+            'track_id' => $track->getKey(),
+            ...$submissionState,
+        ]);
+
+        $submission->participants()->create([
+            'user_id' => $editor->getKey(),
+            'role_id' => $editorRole->getKey(),
+        ]);
+
+        return [
+            'conference' => $conference,
+            'scheduledConference' => $scheduledConference,
+            'track' => $track,
+            'author' => $author,
+            'editor' => $editor,
+            'submission' => $submission,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- Show the full normal decision set in Change Decision panels for Call for Abstract, Peer Review, and Presentation.
- Remove status filters that hid still-valid decisions, while preserving hard locks for published, withdrawn, payment, and queued states where applicable.
- Add state transitions so repeated decisions and decisions from later statuses can run safely.
- Add regression coverage for decision visibility and cross-status transitions.

## Testing
- `php artisan test tests/Feature/SubmissionDecisionActionsTest.php`
- `php artisan test`
- `./vendor/bin/pint --test ...`
- `git diff --check`