### PR TITLE
Update public auth pages to simple layout

### DIFF
--- a/app/Frontend/ScheduledConference/Pages/Login.php
+++ b/app/Frontend/ScheduledConference/Pages/Login.php
@@ -21,7 +21,7 @@ use Filament\Support\Enums\Alignment;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Validation\ValidationException;
 
-class Login extends WebsiteLogin implements HasForms, HasActions
+class Login extends WebsiteLogin implements HasActions, HasForms
 {
     use HasScheduledConferenceAuthLogo;
     use InteractsWithActions;
@@ -82,6 +82,7 @@ class Login extends WebsiteLogin implements HasForms, HasActions
                         TextInput::make('password')
                             ->label(__('general.password'))
                             ->password()
+                            ->revealable()
                             ->required()
                             ->autocomplete('current-password')
                             ->columnSpanFull(),
@@ -169,7 +170,7 @@ class Login extends WebsiteLogin implements HasForms, HasActions
         $this->validate();
 
         if (
-            !auth()->attempt([
+            ! auth()->attempt([
                 'email' => $this->email,
                 'password' => $this->password,
             ], $this->remember)

--- a/app/Frontend/ScheduledConference/Pages/PrivacyStatement.php
+++ b/app/Frontend/ScheduledConference/Pages/PrivacyStatement.php
@@ -2,15 +2,60 @@
 
 namespace App\Frontend\ScheduledConference\Pages;
 
+use App\Frontend\ScheduledConference\Pages\Concerns\HasScheduledConferenceAuthLogo;
 use App\Frontend\Website\Pages\Page;
+use Filament\Support\Enums\MaxWidth;
+use Illuminate\Contracts\Support\Htmlable;
 
 class PrivacyStatement extends Page
 {
+    use HasScheduledConferenceAuthLogo;
+
     protected static string $view = 'frontend.scheduledConference.pages.privacy-statement';
+
+    protected static string $layout = 'frontend.scheduledConference.components.layout.simple-with-platform-footer';
 
     public function mount()
     {
         //
+    }
+
+    public static function getLayout(): string
+    {
+        return static::$layout;
+    }
+
+    public function getMaxWidth(): MaxWidth|string|null
+    {
+        return MaxWidth::FourExtraLarge;
+    }
+
+    protected function getLayoutData(): array
+    {
+        return [
+            'maxWidth' => $this->getMaxWidth(),
+        ];
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getRenderHookScopes(): array
+    {
+        return [static::class];
+    }
+
+    public function getHeading(): string|Htmlable
+    {
+        return $this->getTitle();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getExtraBodyAttributes(): array
+    {
+        return [];
     }
 
     public function getBreadcrumbs(): array

--- a/app/Frontend/ScheduledConference/Pages/Register.php
+++ b/app/Frontend/ScheduledConference/Pages/Register.php
@@ -213,12 +213,14 @@ class Register extends Page implements HasActions, HasForms
                         TextInput::make('password')
                             ->label(__('general.password'))
                             ->password()
+                            ->revealable()
                             ->rules($rules['password'])
                             ->required(in_array('required', $rules['password']))
                             ->columnSpan(1),
                         TextInput::make('password_confirmation')
                             ->label(__('general.password_confirmation'))
                             ->password()
+                            ->revealable()
                             ->required()
                             ->columnSpan(1),
                         Checkbox::make('privacy_statement_agree')

--- a/app/Frontend/ScheduledConference/Pages/Register.php
+++ b/app/Frontend/ScheduledConference/Pages/Register.php
@@ -29,7 +29,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\HtmlString;
 use Squire\Models\Country;
 
-class Register extends Page implements HasForms, HasActions
+class Register extends Page implements HasActions, HasForms
 {
     use HasScheduledConferenceAuthLogo;
     use InteractsWithActions;
@@ -192,7 +192,7 @@ class Register extends Page implements HasForms, HasActions
                             ->columnSpan(1),
                         Select::make('country')
                             ->label(__('general.country'))
-                            ->options(fn() => Country::all()->pluck('name', 'id'))
+                            ->options(fn () => Country::all()->pluck('name', 'id'))
                             ->searchable()
                             ->rules($rules['country'])
                             ->required(in_array('required', $rules['country']))
@@ -222,9 +222,7 @@ class Register extends Page implements HasForms, HasActions
                             ->required()
                             ->columnSpan(1),
                         Checkbox::make('privacy_statement_agree')
-                            ->label(fn() => new HtmlString(__('general.privacy_statement_agree', [
-                                'url' => route(PrivacyStatement::getRouteName()),
-                            ])))
+                            ->label(fn () => $this->getPrivacyStatementAgreeLabel())
                             ->rules($rules['privacy_statement_agree'])
                             ->required(in_array('required', $rules['privacy_statement_agree']))
                             ->columnSpanFull(),
@@ -237,6 +235,17 @@ class Register extends Page implements HasForms, HasActions
     public function form(Form $form): Form
     {
         return $form;
+    }
+
+    protected function getPrivacyStatementAgreeLabel(): HtmlString
+    {
+        return new HtmlString(str_replace(
+            'class="link link-primary link-hover"',
+            'class="fi-simple-link"',
+            __('general.privacy_statement_agree', [
+                'url' => route(PrivacyStatement::getRouteName()),
+            ]),
+        ));
     }
 
     /**
@@ -304,7 +313,7 @@ class Register extends Page implements HasForms, HasActions
 
     public function register()
     {
-        if (!app()->getCurrentScheduledConference()->getMeta('allow_registration')) {
+        if (! app()->getCurrentScheduledConference()->getMeta('allow_registration')) {
             abort(403);
         }
 

--- a/app/Frontend/Website/Pages/Login.php
+++ b/app/Frontend/Website/Pages/Login.php
@@ -5,15 +5,32 @@ namespace App\Frontend\Website\Pages;
 use App\Events\UserLoggedIn;
 use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
 use DanHarrin\LivewireRateLimiting\WithRateLimiting;
+use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Forms\Components\Checkbox;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Forms\Form;
+use Filament\Pages\Concerns\InteractsWithFormActions;
+use Filament\Support\Enums\Alignment;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\Facades\Vite;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Rule;
 
-class Login extends Page
+class Login extends Page implements HasActions, HasForms
 {
+    use InteractsWithActions;
+    use InteractsWithFormActions;
+    use InteractsWithForms;
     use WithRateLimiting;
 
     protected static string $view = 'frontend.website.pages.login';
+
+    protected static string $layout = 'frontend.scheduledConference.components.layout.simple-with-platform-footer';
 
     #[Rule('required|email')]
     public ?string $email = null;
@@ -33,9 +50,42 @@ class Login extends Page
         }
     }
 
+    public static function getLayout(): string
+    {
+        return static::$layout;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getRenderHookScopes(): array
+    {
+        return [static::class];
+    }
+
     public function getTitle(): string|Htmlable
     {
         return __('general.login');
+    }
+
+    public function getHeading(): string|Htmlable
+    {
+        return $this->getTitle();
+    }
+
+    public function getAuthLogoUrl(): string
+    {
+        return Vite::asset('resources/assets/images/logo.png');
+    }
+
+    public function getAuthLogoAltText(): string
+    {
+        return config('app.name', 'Leconfe');
+    }
+
+    public function getAuthLogoHomeUrl(): string
+    {
+        return url('/');
     }
 
     public function getRedirectUrl(): string
@@ -57,6 +107,76 @@ class Login extends Page
             url('/') => __('general.home'),
             __('general.login'),
         ];
+    }
+
+    /**
+     * @return array<int | string, string | Form>
+     */
+    protected function getForms(): array
+    {
+        return [
+            'form' => $this->form(
+                $this->makeForm()
+                    ->schema([
+                        TextInput::make('email')
+                            ->label(__('general.email'))
+                            ->email()
+                            ->required()
+                            ->autofocus()
+                            ->autocomplete('username')
+                            ->columnSpanFull(),
+                        TextInput::make('password')
+                            ->label(__('general.password'))
+                            ->password()
+                            ->required()
+                            ->autocomplete('current-password')
+                            ->columnSpanFull(),
+                        Checkbox::make('remember')
+                            ->label(__('general.remember_me'))
+                            ->columnSpanFull(),
+                    ]),
+            ),
+        ];
+    }
+
+    public function form(Form $form): Form
+    {
+        return $form;
+    }
+
+    /**
+     * @return array<Action | ActionGroup>
+     */
+    protected function getFormActions(): array
+    {
+        return [
+            $this->getAuthenticateFormAction(),
+        ];
+    }
+
+    protected function getAuthenticateFormAction(): Action
+    {
+        return Action::make('authenticate')
+            ->label(__('general.login'))
+            ->submit('login');
+    }
+
+    public function areFormActionsSticky(): bool
+    {
+        return false;
+    }
+
+    public function getFormActionsAlignment(): string|Alignment
+    {
+        return Alignment::Start;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getExtraBodyAttributes(): array
+    {
+        return [];
     }
 
     public function login()

--- a/app/Frontend/Website/Pages/Login.php
+++ b/app/Frontend/Website/Pages/Login.php
@@ -128,6 +128,7 @@ class Login extends Page implements HasActions, HasForms
                         TextInput::make('password')
                             ->label(__('general.password'))
                             ->password()
+                            ->revealable()
                             ->required()
                             ->autocomplete('current-password')
                             ->columnSpanFull(),

--- a/app/Frontend/Website/Pages/ResetPassword.php
+++ b/app/Frontend/Website/Pages/ResetPassword.php
@@ -6,15 +6,31 @@ use App\Mail\Templates\ResetPasswordMail;
 use App\Models\User;
 use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
 use DanHarrin\LivewireRateLimiting\WithRateLimiting;
+use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Forms\Form;
+use Filament\Pages\Concerns\InteractsWithFormActions;
+use Filament\Support\Enums\Alignment;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Vite;
 use Livewire\Attributes\Locked;
 
-class ResetPassword extends Page
+class ResetPassword extends Page implements HasActions, HasForms
 {
+    use InteractsWithActions;
+    use InteractsWithFormActions;
+    use InteractsWithForms;
     use WithRateLimiting;
 
     protected static string $view = 'frontend.website.pages.reset-password';
+
+    protected static string $layout = 'frontend.scheduledConference.components.layout.simple-with-platform-footer';
 
     public ?string $email = null;
 
@@ -28,9 +44,52 @@ class ResetPassword extends Page
         }
     }
 
+    public static function getLayout(): string
+    {
+        return static::$layout;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getRenderHookScopes(): array
+    {
+        return [static::class];
+    }
+
     public function getTitle(): string|Htmlable
     {
         return __('general.reset_password');
+    }
+
+    public function getHeading(): string|Htmlable
+    {
+        return $this->getTitle();
+    }
+
+    public function getAuthLogoUrl(): string
+    {
+        return app()->getCurrentScheduledConference()
+            ?->getFirstMedia('logo')
+            ?->getAvailableUrl(['thumb', 'thumb-xl'])
+            ?? app()->getCurrentConference()
+                ?->getFirstMedia('logo')
+                ?->getAvailableUrl(['thumb', 'thumb-xl'])
+            ?? Vite::asset('resources/assets/images/logo.png');
+    }
+
+    public function getAuthLogoAltText(): string
+    {
+        return app()->getCurrentScheduledConference()?->title
+            ?? app()->getCurrentConference()?->name
+            ?? config('app.name', 'Leconfe');
+    }
+
+    public function getAuthLogoHomeUrl(): string
+    {
+        return app()->getCurrentScheduledConference()?->getHomeUrl()
+            ?? app()->getCurrentConference()?->getHomeUrl()
+            ?? url('/');
     }
 
     public function getRedirectUrl(): string
@@ -51,6 +110,67 @@ class ResetPassword extends Page
             url('/') => __('general.home'),
             __('general.reset_password'),
         ];
+    }
+
+    /**
+     * @return array<int | string, string | Form>
+     */
+    protected function getForms(): array
+    {
+        return [
+            'form' => $this->form(
+                $this->makeForm()
+                    ->schema([
+                        TextInput::make('email')
+                            ->label(__('general.email'))
+                            ->email()
+                            ->required()
+                            ->autofocus()
+                            ->autocomplete('username')
+                            ->columnSpanFull(),
+                    ]),
+            ),
+        ];
+    }
+
+    public function form(Form $form): Form
+    {
+        return $form;
+    }
+
+    /**
+     * @return array<Action | ActionGroup>
+     */
+    protected function getFormActions(): array
+    {
+        return [
+            $this->getSubmitFormAction(),
+        ];
+    }
+
+    protected function getSubmitFormAction(): Action
+    {
+        return Action::make('submit')
+            ->label(__('general.reset_password'))
+            ->submit('submit');
+    }
+
+    public function areFormActionsSticky(): bool
+    {
+        return false;
+    }
+
+    public function getFormActionsAlignment(): string|Alignment
+    {
+        return Alignment::Start;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getExtraBodyAttributes(): array
+    {
+        return [];
     }
 
     public function rules()

--- a/app/Frontend/Website/Pages/ResetPasswordConfirmation.php
+++ b/app/Frontend/Website/Pages/ResetPasswordConfirmation.php
@@ -3,25 +3,42 @@
 namespace App\Frontend\Website\Pages;
 
 use App\Models\User;
+use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Forms\Form;
+use Filament\Pages\Concerns\InteractsWithFormActions;
+use Filament\Support\Enums\Alignment;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Vite;
 use Illuminate\Validation\Rules\Password;
 use Livewire\Attributes\Locked;
 use Rahmanramsi\LivewirePageGroup\PageGroup;
 
-class ResetPasswordConfirmation extends Page
+class ResetPasswordConfirmation extends Page implements HasActions, HasForms
 {
+    use InteractsWithActions;
+    use InteractsWithFormActions;
+    use InteractsWithForms;
+
     protected static string $view = 'frontend.website.pages.reset-password-confirmation';
+
+    protected static string $layout = 'frontend.scheduledConference.components.layout.simple-with-platform-footer';
 
     public User $user;
 
     public string $hash;
 
-    public string $password;
+    public ?string $password = null;
 
-    public string $password_confirmation;
+    public ?string $password_confirmation = null;
 
     #[Locked]
     public bool $success = false;
@@ -43,9 +60,52 @@ class ResetPasswordConfirmation extends Page
 
     }
 
+    public static function getLayout(): string
+    {
+        return static::$layout;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getRenderHookScopes(): array
+    {
+        return [static::class];
+    }
+
     public function getTitle(): string|Htmlable
     {
         return __('general.reset_password_confirmation');
+    }
+
+    public function getHeading(): string|Htmlable
+    {
+        return $this->getTitle();
+    }
+
+    public function getAuthLogoUrl(): string
+    {
+        return app()->getCurrentScheduledConference()
+            ?->getFirstMedia('logo')
+            ?->getAvailableUrl(['thumb', 'thumb-xl'])
+            ?? app()->getCurrentConference()
+                ?->getFirstMedia('logo')
+                ?->getAvailableUrl(['thumb', 'thumb-xl'])
+            ?? Vite::asset('resources/assets/images/logo.png');
+    }
+
+    public function getAuthLogoAltText(): string
+    {
+        return app()->getCurrentScheduledConference()?->title
+            ?? app()->getCurrentConference()?->name
+            ?? config('app.name', 'Leconfe');
+    }
+
+    public function getAuthLogoHomeUrl(): string
+    {
+        return app()->getCurrentScheduledConference()?->getHomeUrl()
+            ?? app()->getCurrentConference()?->getHomeUrl()
+            ?? url('/');
     }
 
     public function getRedirectUrl(): string
@@ -66,6 +126,72 @@ class ResetPasswordConfirmation extends Page
             url('/') => __('general.home'),
             __('general.login'),
         ];
+    }
+
+    /**
+     * @return array<int | string, string | Form>
+     */
+    protected function getForms(): array
+    {
+        return [
+            'form' => $this->form(
+                $this->makeForm()
+                    ->schema([
+                        TextInput::make('password')
+                            ->label(__('general.new_password'))
+                            ->password()
+                            ->required()
+                            ->autocomplete('new-password')
+                            ->columnSpanFull(),
+                        TextInput::make('password_confirmation')
+                            ->label(__('general.confirm_password'))
+                            ->password()
+                            ->required()
+                            ->autocomplete('new-password')
+                            ->columnSpanFull(),
+                    ]),
+            ),
+        ];
+    }
+
+    public function form(Form $form): Form
+    {
+        return $form;
+    }
+
+    /**
+     * @return array<Action | ActionGroup>
+     */
+    protected function getFormActions(): array
+    {
+        return [
+            $this->getSubmitFormAction(),
+        ];
+    }
+
+    protected function getSubmitFormAction(): Action
+    {
+        return Action::make('submit')
+            ->label(__('general.submit'))
+            ->submit('submit');
+    }
+
+    public function areFormActionsSticky(): bool
+    {
+        return false;
+    }
+
+    public function getFormActionsAlignment(): string|Alignment
+    {
+        return Alignment::Start;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getExtraBodyAttributes(): array
+    {
+        return [];
     }
 
     public function rules()

--- a/app/Frontend/Website/Pages/ResetPasswordConfirmation.php
+++ b/app/Frontend/Website/Pages/ResetPasswordConfirmation.php
@@ -140,12 +140,14 @@ class ResetPasswordConfirmation extends Page implements HasActions, HasForms
                         TextInput::make('password')
                             ->label(__('general.new_password'))
                             ->password()
+                            ->revealable()
                             ->required()
                             ->autocomplete('new-password')
                             ->columnSpanFull(),
                         TextInput::make('password_confirmation')
                             ->label(__('general.confirm_password'))
                             ->password()
+                            ->revealable()
                             ->required()
                             ->autocomplete('new-password')
                             ->columnSpanFull(),

--- a/resources/panel/css/panel.css
+++ b/resources/panel/css/panel.css
@@ -8,6 +8,10 @@
     /* TODO Apply alignment tabs to left, currently break contained tab when this css applied */
     /* @apply ml-0 mr-auto; */
 }
+
+.fi-simple-link {
+    @apply text-primary-600 underline transition hover:text-primary-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-600 focus-visible:ring-offset-2 dark:text-primary-400 dark:hover:text-primary-300 dark:focus-visible:ring-primary-500;
+}
 /* 
 .fi-sidebar {
     @apply lg:!bg-white dark:lg:!bg-gray-900 !rounded-xl my-4 ml-4 -left-6 lg:left-0;

--- a/resources/views/frontend/scheduledConference/pages/login.blade.php
+++ b/resources/views/frontend/scheduledConference/pages/login.blade.php
@@ -29,7 +29,7 @@
 
             <label class="label-text">
                 <x-website::link :href="$resetPasswordUrl"
-                    class="link link-primary">{{ __('general.forgot_password_question') }}</x-website::link>
+                    class="fi-simple-link">{{ __('general.forgot_password_question') }}</x-website::link>
             </label>
             <x-filament-panels::form.actions :actions="$this->getFormActions()" :fullWidth="true" />
         </x-filament-panels::form>

--- a/resources/views/frontend/scheduledConference/pages/privacy-statement.blade.php
+++ b/resources/views/frontend/scheduledConference/pages/privacy-statement.blade.php
@@ -1,14 +1,33 @@
-<x-website::layouts.main>
-    <div class="mb-6">
-        <x-website::breadcrumbs :breadcrumbs="$this->getBreadcrumbs()" />
-    </div>
-    <div class="relative">
-        <div class="flex mb-5 space-x-4">
-            <h1 class="text-xl font-semibold min-w-fit">{{ $this->getTitle() }}</h1>
-            <hr class="w-full h-px my-auto bg-gray-200 border-0 dark:bg-gray-700">
-        </div>
-        <div class="user-content">
+<div class="fi-simple-page">
+    {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::SIMPLE_PAGE_START, scopes: $this->getRenderHookScopes()) }}
+
+    <a
+        href="{{ $this->getAuthLogoHomeUrl() }}"
+        class="mb-6 inline-flex items-center gap-x-1.5 rounded-lg px-3 py-2 text-sm font-semibold text-gray-700 ring-1 ring-inset ring-gray-300 transition hover:bg-gray-50 dark:text-gray-200 dark:ring-gray-700 dark:hover:bg-white/5"
+    >
+        <x-heroicon-m-arrow-left class="h-4 w-4" />
+        Back to home
+    </a>
+
+    <section class="grid auto-cols-fr gap-y-6">
+        <header class="fi-simple-header flex flex-col items-center">
+            <a href="{{ $this->getAuthLogoHomeUrl() }}" class="mb-4">
+                <img
+                    src="{{ $this->getAuthLogoUrl() }}"
+                    alt="{{ $this->getAuthLogoAltText() }}"
+                    class="fi-logo max-h-20 w-auto object-contain"
+                />
+            </a>
+
+            <h1 class="fi-simple-header-heading text-center text-2xl font-bold tracking-tight text-gray-950 dark:text-white">
+                {{ $this->getHeading() }}
+            </h1>
+        </header>
+
+        <div class="user-content text-gray-700 dark:text-gray-200">
             {{ new Illuminate\Support\HtmlString($privacyStatement) }}
         </div>
-    </div>
-</x-website::layouts.main>
+    </section>
+
+    {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::SIMPLE_PAGE_END, scopes: $this->getRenderHookScopes()) }}
+</div>

--- a/resources/views/frontend/website/pages/login.blade.php
+++ b/resources/views/frontend/website/pages/login.blade.php
@@ -1,61 +1,47 @@
-<x-website::layouts.main class="space-y-2">
-    <div class="mb-6">
-        <x-website::breadcrumbs :breadcrumbs="$this->getBreadcrumbs()" />
-    </div>
-    <div class="relative">
-        <div class="flex mb-5 space-x-4">
-            <h1 class="text-xl font-semibold min-w-fit">{{ __('general.login') }}</h1>
-            <hr class="w-full h-px my-auto bg-gray-200 border-0 dark:bg-gray-700">
-        </div>
-        <form wire:submit='login' class="space-y-4">
-            @error('throttle')
-                <div class="text-sm text-red-600">
-                    {{ $message }}
-                </div>
-            @enderror
-            <div class="gap-2 form-control sm:col-span-6">
-                <label class="label-text">
-                    {{ __('general.email') }} <span class="text-red-500">*</span>
-                </label>
-                <input type="email" name="email" class="input input-sm" wire:model="email" required/>
-                @error('email')
-                    <div class="text-sm text-red-600">
-                        {{ $message }}
-                    </div>
-                @enderror
-            </div>
-            <div class="gap-2 form-control sm:col-span-3">
-                <label class="label-text">
-                    {{ __('general.password') }} <span class="text-red-500">*</span>
-                </label>
-                <input type="password" name="password" class="input input-sm" wire:model="password" required />
-                <label class="label-text">
-                    <x-website::link :href="$resetPasswordUrl" class="link link-primary">{{ __('general.forgot_password_question') }}</x-website::link>
-                </label>
-                @error('password')
-                    <div class="text-sm text-red-600">
-                        {{ $message }}
-                    </div>
-                @enderror
-            </div>
-            <div class="form-control">
-                <label class="flex items-center gap-2 cursor-pointer">
-                    <input type="checkbox" wire:model='remember' class="checkbox checkbox-sm" />
-                    <span class="label-text">{{ __('general.remember_me') }}</span>
-                </label>
-            </div>
-            <div class="flex gap-2">
-                <button type="submit" class="btn btn-primary btn-sm" wire:loading.attr="disabled">
-                    <span class="loading loading-spinner loading-xs" wire:loading></span>
-                    {{ __('general.login') }}
-                </button>
-                @if($registerUrl)
-                <x-website::link class="btn btn-outline btn-sm" :href="$registerUrl">
-                    {{ __('general.register') }}
-                </x-website::link>
-                @endif
-            </div>
-        </form>
-    </div>
+<div class="fi-simple-page">
+    {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::SIMPLE_PAGE_START, scopes: $this->getRenderHookScopes()) }}
 
-</x-website::layouts.main>
+    <a
+        href="{{ $this->getAuthLogoHomeUrl() }}"
+        class="mb-6 inline-flex items-center gap-x-1.5 rounded-lg px-3 py-2 text-sm font-semibold text-gray-700 ring-1 ring-inset ring-gray-300 transition hover:bg-gray-50 dark:text-gray-200 dark:ring-gray-700 dark:hover:bg-white/5"
+    >
+        <x-heroicon-m-arrow-left class="h-4 w-4" />
+        Back to home
+    </a>
+
+    <section class="grid auto-cols-fr gap-y-6">
+        <header class="fi-simple-header flex flex-col items-center">
+            <a href="{{ $this->getAuthLogoHomeUrl() }}" class="mb-4">
+                <img
+                    src="{{ $this->getAuthLogoUrl() }}"
+                    alt="{{ $this->getAuthLogoAltText() }}"
+                    class="fi-logo max-h-20 w-auto object-contain"
+                />
+            </a>
+
+            <h1 class="fi-simple-header-heading text-center text-2xl font-bold tracking-tight text-gray-950 dark:text-white">
+                {{ $this->getHeading() }}
+            </h1>
+        </header>
+
+        @error('throttle')
+            <div class="text-sm text-danger-600 dark:text-danger-400">
+                {{ $message }}
+            </div>
+        @enderror
+
+        <x-filament-panels::form wire:submit="login">
+            {{ $this->form }}
+
+            <a href="{{ $resetPasswordUrl }}" class="fi-simple-link">
+                {{ __('general.forgot_password_question') }}
+            </a>
+
+            <x-filament-panels::form.actions :actions="$this->getFormActions()" :fullWidth="true" />
+        </x-filament-panels::form>
+    </section>
+
+    <x-filament-actions::modals />
+
+    {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::SIMPLE_PAGE_END, scopes: $this->getRenderHookScopes()) }}
+</div>

--- a/resources/views/frontend/website/pages/reset-password-confirmation.blade.php
+++ b/resources/views/frontend/website/pages/reset-password-confirmation.blade.php
@@ -1,55 +1,53 @@
-<x-website::layouts.main class="space-y-2">
-    <div class="mb-6">
-        <x-website::breadcrumbs :breadcrumbs="$this->getBreadcrumbs()" />
-    </div>
-    <div class="relative">
-        <div class="flex mb-5 space-x-4">
-            <h1 class="text-xl font-semibold min-w-fit">{{ __('general.reset_password') }}</h1>
-            <hr class="w-full h-px my-auto bg-gray-200 border-0 dark:bg-gray-700">
-        </div>
-        @if(!$success)
-        <form wire:submit='submit' class="space-y-4">
-            <p class="text-sm text-gray-700">
+<div class="fi-simple-page">
+    {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::SIMPLE_PAGE_START, scopes: $this->getRenderHookScopes()) }}
+
+    <a
+        href="{{ $this->getAuthLogoHomeUrl() }}"
+        class="mb-6 inline-flex items-center gap-x-1.5 rounded-lg px-3 py-2 text-sm font-semibold text-gray-700 ring-1 ring-inset ring-gray-300 transition hover:bg-gray-50 dark:text-gray-200 dark:ring-gray-700 dark:hover:bg-white/5"
+    >
+        <x-heroicon-m-arrow-left class="h-4 w-4" />
+        Back to home
+    </a>
+
+    <section class="grid auto-cols-fr gap-y-6">
+        <header class="fi-simple-header flex flex-col items-center">
+            <a href="{{ $this->getAuthLogoHomeUrl() }}" class="mb-4">
+                <img
+                    src="{{ $this->getAuthLogoUrl() }}"
+                    alt="{{ $this->getAuthLogoAltText() }}"
+                    class="fi-logo max-h-20 w-auto object-contain"
+                />
+            </a>
+
+            <h1 class="fi-simple-header-heading text-center text-2xl font-bold tracking-tight text-gray-950 dark:text-white">
+                {{ $this->getHeading() }}
+            </h1>
+        </header>
+
+        @if (! $success)
+            <p class="text-sm leading-6 text-gray-600 dark:text-gray-300">
                 {{ __('general.enter_password_to_update') }}
             </p>
-            <div class="gap-2 form-control sm:col-span-6">
-                <label class="label-text">
-                    {{ __('general.new_password') }} <span class="text-red-500">*</span>
-                </label>
-                <input type="password" name="password" class="input input-sm max-w-md" wire:model="password" required />
-                @error('password')
-                    <div class="text-sm text-red-600">
-                        {{ $message }}
-                    </div>
-                @enderror
-            </div>
-            <div class="gap-2 form-control sm:col-span-6">
-                <label class="label-text">
-                    {{ __('general.confirm_password') }} <span class="text-red-500">*</span>
-                </label>
-                <input type="password" name="password_confirmation" class="input input-sm max-w-md" wire:model="password_confirmation" required />
-                @error('password_confirmation')
-                    <div class="text-sm text-red-600">
-                        {{ $message }}
-                    </div>
-                @enderror
-            </div>
-            <div class="flex gap-2">
-                <button type="submit" class="btn btn-primary btn-sm" wire:loading.attr="disabled">
-                    <span class="loading loading-spinner loading-xs" wire:loading></span>
-                    {{ __('general.submit') }}
-                </button>
-            </div>
-        </form>
+
+            <x-filament-panels::form wire:submit="submit">
+                {{ $this->form }}
+
+                <x-filament-panels::form.actions :actions="$this->getFormActions()" :fullWidth="true" />
+            </x-filament-panels::form>
         @else
-        <div class="space-y-4">
-            <p class="text-sm text-gray-700">{{ __('general.reset_password_update_success') }}</p>
-            <x-website::link class="btn btn-outline btn-sm" :href="app()->getLoginUrl()">
-                {{ __('general.login') }}
-            </x-website::link>
-        </div>
+            <div class="space-y-4">
+                <p class="text-sm leading-6 text-gray-600 dark:text-gray-300">
+                    {{ __('general.reset_password_update_success') }}
+                </p>
+
+                <a href="{{ app()->getLoginUrl() }}" class="fi-simple-link">
+                    {{ __('general.login') }}
+                </a>
+            </div>
         @endif
+    </section>
 
-    </div>
+    <x-filament-actions::modals />
 
-</x-website::layouts.main>
+    {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::SIMPLE_PAGE_END, scopes: $this->getRenderHookScopes()) }}
+</div>

--- a/resources/views/frontend/website/pages/reset-password.blade.php
+++ b/resources/views/frontend/website/pages/reset-password.blade.php
@@ -1,55 +1,59 @@
-<x-website::layouts.main class="space-y-2">
-    <div class="mb-6">
-        <x-website::breadcrumbs :breadcrumbs="$this->getBreadcrumbs()" />
-    </div>
-    <div class="relative">
-        <div class="flex mb-5 space-x-4">
-            <h1 class="text-xl font-semibold min-w-fit">{{ __('general.reset_password') }}</h1>
-            <hr class="w-full h-px my-auto bg-gray-200 border-0 dark:bg-gray-700">
-        </div>
-        @if(!$success)
-        <form wire:submit='submit' class="space-y-4">
+<div class="fi-simple-page">
+    {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::SIMPLE_PAGE_START, scopes: $this->getRenderHookScopes()) }}
+
+    <a
+        href="{{ $this->getAuthLogoHomeUrl() }}"
+        class="mb-6 inline-flex items-center gap-x-1.5 rounded-lg px-3 py-2 text-sm font-semibold text-gray-700 ring-1 ring-inset ring-gray-300 transition hover:bg-gray-50 dark:text-gray-200 dark:ring-gray-700 dark:hover:bg-white/5"
+    >
+        <x-heroicon-m-arrow-left class="h-4 w-4" />
+        Back to home
+    </a>
+
+    <section class="grid auto-cols-fr gap-y-6">
+        <header class="fi-simple-header flex flex-col items-center">
+            <a href="{{ $this->getAuthLogoHomeUrl() }}" class="mb-4">
+                <img
+                    src="{{ $this->getAuthLogoUrl() }}"
+                    alt="{{ $this->getAuthLogoAltText() }}"
+                    class="fi-logo max-h-20 w-auto object-contain"
+                />
+            </a>
+
+            <h1 class="fi-simple-header-heading text-center text-2xl font-bold tracking-tight text-gray-950 dark:text-white">
+                {{ $this->getHeading() }}
+            </h1>
+        </header>
+
+        @if (! $success)
             @error('throttle')
-                <div class="text-sm text-red-600">
+                <div class="text-sm text-danger-600 dark:text-danger-400">
                     {{ $message }}
                 </div>
             @enderror
-            <p class="text-sm text-gray-700">
-                
+
+            <p class="text-sm leading-6 text-gray-600 dark:text-gray-300">
                 {{ __('general.please_enter_email_to_reset_password') }}
             </p>
-            <div class="gap-2 form-control sm:col-span-6">
-                <label class="label-text">
-                    {{ __('general.email') }} <span class="text-red-500">*</span>
-                </label>
-                <input type="email" name="email" class="input input-sm max-w-md" wire:model="email" required />
-                @error('email')
-                    <div class="text-sm text-red-600">
-                        {{ $message }}
-                    </div>
-                @enderror
-            </div>
- 
-            <div class="flex gap-2">
-                <button type="submit" class="btn btn-primary btn-sm" wire:loading.attr="disabled">
-                    <span class="loading loading-spinner loading-xs" wire:loading></span>
-                    {{ __('general.reset_password') }}
-                </button>
-                @if($registerUrl)
-                <x-website::link class="btn btn-outline btn-sm" :href="$registerUrl">
-                    {{ __('general.register') }}
-                </x-website::link>
-                @endif
-            </div>
-        </form>
-        @else 
+
+            <x-filament-panels::form wire:submit="submit">
+                {{ $this->form }}
+
+                <x-filament-panels::form.actions :actions="$this->getFormActions()" :fullWidth="true" />
+            </x-filament-panels::form>
+        @else
             <div class="space-y-4">
-                <p class="text-sm text-gray-700">{{ __('general.reset_password_mail_sent') }}</p>
-                <x-website::link class="btn btn-outline btn-sm" :href="app()->getLoginUrl()">
+                <p class="text-sm leading-6 text-gray-600 dark:text-gray-300">
+                    {{ __('general.reset_password_mail_sent') }}
+                </p>
+
+                <a href="{{ app()->getLoginUrl() }}" class="fi-simple-link">
                     {{ __('general.login') }}
-                </x-website::link>
+                </a>
             </div>
         @endif
-    </div>
+    </section>
 
-</x-website::layouts.main>
+    <x-filament-actions::modals />
+
+    {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::SIMPLE_PAGE_END, scopes: $this->getRenderHookScopes()) }}
+</div>

--- a/tests/Feature/ScheduledConferenceLoginTest.php
+++ b/tests/Feature/ScheduledConferenceLoginTest.php
@@ -2,30 +2,29 @@
 
 namespace Tests\Feature;
 
-use App\Frontend\ScheduledConference\Pages\Register;
+use App\Frontend\ScheduledConference\Pages\Login;
 use App\Models\Conference;
 use App\Models\ScheduledConference;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
-class ScheduledConferenceRegisterTest extends TestCase
+class ScheduledConferenceLoginTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_privacy_statement_link_uses_panel_generated_link_class(): void
+    public function test_scheduled_conference_login_password_can_be_revealed(): void
     {
         $scheduledConference = $this->makeScheduledConference();
 
         $this->withoutVite()
-            ->get(route(Register::getRouteName('scheduledConference'), [
+            ->get(route(Login::getRouteName('scheduledConference'), [
                 'conference' => $scheduledConference->conference->path,
                 'serie' => $scheduledConference->path,
             ]))
             ->assertOk()
-            ->assertSee('class="fi-simple-link"', false)
+            ->assertSee('fi-input', false)
             ->assertSee('Show password', false)
-            ->assertSee('Hide password', false)
-            ->assertDontSee('link link-primary', false);
+            ->assertSee('Hide password', false);
     }
 
     protected function makeScheduledConference(): ScheduledConference

--- a/tests/Feature/ScheduledConferencePrivacyStatementTest.php
+++ b/tests/Feature/ScheduledConferencePrivacyStatementTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Frontend\ScheduledConference\Pages\Login;
+use App\Frontend\ScheduledConference\Pages\PrivacyStatement;
+use App\Models\Conference;
+use App\Models\ScheduledConference;
+use Filament\Support\Enums\MaxWidth;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ScheduledConferencePrivacyStatementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_privacy_statement_uses_simple_auth_layout_without_website_theme(): void
+    {
+        $scheduledConference = $this->makeScheduledConferenceWithPrivacyStatement('<p>Personal data processing details.</p>');
+
+        $this->assertSame(Login::getLayout(), PrivacyStatement::getLayout());
+        $this->assertSame(MaxWidth::FourExtraLarge, $this->getPrivacyStatementLayoutData()['maxWidth']);
+
+        Livewire::test(PrivacyStatement::class)
+            ->assertSeeHtml('fi-simple-page')
+            ->assertSeeHtml('Back to home')
+            ->assertSeeHtml('<p>Personal data processing details.</p>')
+            ->assertDontSeeHtml('website::layouts.main');
+
+        $this->withoutVite()
+            ->get(route(PrivacyStatement::getRouteName('scheduledConference'), [
+                'conference' => $scheduledConference->conference->path,
+                'serie' => $scheduledConference->path,
+            ]))
+            ->assertOk()
+            ->assertSee('fi-simple-layout', false)
+            ->assertSee('fi-simple-page', false)
+            ->assertSee('<p>Personal data processing details.</p>', false);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getPrivacyStatementLayoutData(): array
+    {
+        return (function (): array {
+            return $this->getLayoutData();
+        })->call(new PrivacyStatement);
+    }
+
+    protected function makeScheduledConferenceWithPrivacyStatement(string $privacyStatement): ScheduledConference
+    {
+        $conference = Conference::query()->create([
+            'name' => 'Test Conference',
+            'path' => 'test-conference',
+        ]);
+
+        $scheduledConference = ScheduledConference::query()->create([
+            'conference_id' => $conference->getKey(),
+            'title' => 'Test Scheduled Conference',
+            'path' => 'test-scheduled-conference',
+            'is_published' => true,
+        ]);
+        $scheduledConference->setMeta('privacy_statement', $privacyStatement);
+
+        app()->setCurrentConferenceId($conference->getKey());
+        app()->setCurrentScheduledConferenceId($scheduledConference->getKey());
+
+        return $scheduledConference;
+    }
+}

--- a/tests/Feature/ScheduledConferenceRegisterTest.php
+++ b/tests/Feature/ScheduledConferenceRegisterTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Frontend\ScheduledConference\Pages\Register;
+use App\Models\Conference;
+use App\Models\ScheduledConference;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ScheduledConferenceRegisterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_privacy_statement_link_uses_panel_generated_link_class(): void
+    {
+        $scheduledConference = $this->makeScheduledConference();
+
+        $this->withoutVite()
+            ->get(route(Register::getRouteName('scheduledConference'), [
+                'conference' => $scheduledConference->conference->path,
+                'serie' => $scheduledConference->path,
+            ]))
+            ->assertOk()
+            ->assertSee('class="fi-simple-link"', false)
+            ->assertDontSee('link link-primary', false);
+    }
+
+    protected function makeScheduledConference(): ScheduledConference
+    {
+        $conference = Conference::query()->create([
+            'name' => 'Test Conference',
+            'path' => 'test-conference',
+        ]);
+
+        $scheduledConference = ScheduledConference::query()->create([
+            'conference_id' => $conference->getKey(),
+            'title' => 'Test Scheduled Conference',
+            'path' => 'test-scheduled-conference',
+            'is_published' => true,
+        ]);
+
+        app()->setCurrentConferenceId($conference->getKey());
+        app()->setCurrentScheduledConferenceId($scheduledConference->getKey());
+
+        return $scheduledConference;
+    }
+}

--- a/tests/Feature/WebsiteLoginTest.php
+++ b/tests/Feature/WebsiteLoginTest.php
@@ -19,6 +19,8 @@ class WebsiteLoginTest extends TestCase
             ->assertSee('fi-simple-page', false)
             ->assertSee('class="fi-simple-link"', false)
             ->assertSee('fi-input', false)
+            ->assertSee('Show password', false)
+            ->assertSee('Hide password', false)
             ->assertDontSee('website::layouts.main', false)
             ->assertDontSee('link link-primary', false)
             ->assertDontSee('input input-sm', false)

--- a/tests/Feature/WebsiteLoginTest.php
+++ b/tests/Feature/WebsiteLoginTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Frontend\Website\Pages\Login;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class WebsiteLoginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_website_login_uses_simple_panel_layout(): void
+    {
+        $this->withoutVite()
+            ->get(route(Login::getRouteName('website')))
+            ->assertOk()
+            ->assertSee('fi-simple-layout', false)
+            ->assertSee('fi-simple-page', false)
+            ->assertSee('class="fi-simple-link"', false)
+            ->assertSee('fi-input', false)
+            ->assertDontSee('website::layouts.main', false)
+            ->assertDontSee('link link-primary', false)
+            ->assertDontSee('input input-sm', false)
+            ->assertDontSee('btn btn-primary', false);
+    }
+}

--- a/tests/Feature/WebsiteResetPasswordConfirmationTest.php
+++ b/tests/Feature/WebsiteResetPasswordConfirmationTest.php
@@ -22,6 +22,8 @@ class WebsiteResetPasswordConfirmationTest extends TestCase
             ->assertSee('fi-simple-layout', false)
             ->assertSee('fi-simple-page', false)
             ->assertSee('fi-input', false)
+            ->assertSee('Show password', false)
+            ->assertSee('Hide password', false)
             ->assertDontSee('website::layouts.main', false)
             ->assertDontSee('input input-sm', false)
             ->assertDontSee('btn btn-primary', false);

--- a/tests/Feature/WebsiteResetPasswordConfirmationTest.php
+++ b/tests/Feature/WebsiteResetPasswordConfirmationTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Frontend\Website\Pages\ResetPasswordConfirmation;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\URL;
+use Livewire\Drawer\Utils;
+use Tests\TestCase;
+
+class WebsiteResetPasswordConfirmationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_website_reset_password_confirmation_uses_simple_panel_layout(): void
+    {
+        $this->withoutVite()
+            ->get($this->makeResetPasswordConfirmationUrl())
+            ->assertOk()
+            ->assertSee('fi-simple-layout', false)
+            ->assertSee('fi-simple-page', false)
+            ->assertSee('fi-input', false)
+            ->assertDontSee('website::layouts.main', false)
+            ->assertDontSee('input input-sm', false)
+            ->assertDontSee('btn btn-primary', false);
+    }
+
+    public function test_reset_password_confirmation_submit_still_updates_password(): void
+    {
+        $user = $this->makeResetPasswordUser();
+        $response = $this->withoutVite()
+            ->get($this->makeResetPasswordConfirmationUrl($user))
+            ->assertOk();
+
+        $snapshot = Utils::extractAttributeDataFromHtml($response->getContent(), 'wire:snapshot');
+
+        $this->withHeader('X-Livewire', true)->postJson(app('livewire')->getUpdateUri(), [
+            'components' => [
+                [
+                    'snapshot' => json_encode($snapshot),
+                    'updates' => [
+                        'password' => 'new-password-12345',
+                        'password_confirmation' => 'new-password-12345',
+                    ],
+                    'calls' => [
+                        [
+                            'method' => 'submit',
+                            'params' => [],
+                            'path' => '',
+                        ],
+                    ],
+                ],
+            ],
+        ])
+            ->assertOk();
+
+        $this->assertTrue(Hash::check('new-password-12345', $user->refresh()->password));
+    }
+
+    protected function makeResetPasswordConfirmationUrl(?User $user = null): string
+    {
+        $user ??= $this->makeResetPasswordUser();
+
+        return URL::temporarySignedRoute(
+            ResetPasswordConfirmation::getRouteName('website'),
+            now()->addHour(),
+            [
+                'user' => $user->email,
+                'hash' => $this->makeResetPasswordHash($user),
+            ],
+        );
+    }
+
+    protected function makeResetPasswordHash(User $user): string
+    {
+        return sha1($user->email.$user->password.$user->getMeta('last_login'));
+    }
+
+    protected function makeResetPasswordUser(): User
+    {
+        return User::factory()->create([
+            'email' => 'reset-password-confirmation-'.str()->random(8).'@example.test',
+            'password' => Hash::make('password12345'),
+        ]);
+    }
+}

--- a/tests/Feature/WebsiteResetPasswordTest.php
+++ b/tests/Feature/WebsiteResetPasswordTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Frontend\Website\Pages\ResetPassword;
+use App\Mail\Templates\ResetPasswordMail;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Mail;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class WebsiteResetPasswordTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_website_reset_password_uses_simple_panel_layout(): void
+    {
+        $this->withoutVite()
+            ->get(route(ResetPassword::getRouteName('website')))
+            ->assertOk()
+            ->assertSee('fi-simple-layout', false)
+            ->assertSee('fi-simple-page', false)
+            ->assertSee('fi-input', false)
+            ->assertDontSee('website::layouts.main', false)
+            ->assertDontSee('input input-sm', false)
+            ->assertDontSee('btn btn-primary', false);
+    }
+
+    public function test_reset_password_submit_still_sends_email(): void
+    {
+        Mail::fake();
+
+        $user = User::factory()->create([
+            'email' => 'reset-password@example.test',
+            'password' => Hash::make('password12345'),
+        ]);
+
+        Livewire::test(ResetPassword::class)
+            ->set('email', $user->email)
+            ->call('submit')
+            ->assertSet('success', true);
+
+        Mail::assertQueued(ResetPasswordMail::class, 1);
+    }
+}


### PR DESCRIPTION
## Summary
- Move public privacy statement, website login, reset password, and reset password confirmation pages to the simple auth layout.
- Replace legacy public link classes with a panel-generated `fi-simple-link` style.
- Add reveal-password controls to public login, register, and reset-password-confirmation password fields.
- Add feature coverage for the updated public auth/register/privacy pages and reset-password-confirmation password update flow.

## Verification
- `php artisan test tests/Feature/WebsiteLoginTest.php tests/Feature/WebsiteResetPasswordTest.php tests/Feature/WebsiteResetPasswordConfirmationTest.php tests/Feature/InvitationRegisterTest.php tests/Feature/ScheduledConferenceRegisterTest.php tests/Feature/ScheduledConferenceLoginTest.php tests/Feature/ScheduledConferencePrivacyStatementTest.php`
- `npm run build`
- Browser check for website login confirmed simple layout, show/hide password buttons, password reveal binding, and no legacy DaisyUI classes.
- Browser check for signed reset-password-confirmation URL confirmed simple layout, Filament input, no website navbar, and no legacy DaisyUI classes.