### PR TITLE
Fix reviewer assignment lifecycle

### DIFF
--- a/app/Models/Review.php
+++ b/app/Models/Review.php
@@ -2,8 +2,10 @@
 
 namespace App\Models;
 
+use App\Constants\ReviewerStatus;
 use GeneaLabs\LaravelModelCaching\Traits\Cachable;
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Plank\Metable\Metable;
@@ -44,6 +46,31 @@ class Review extends Model implements HasMedia
     public function reviewSubmitted(): bool
     {
         return ! is_null($this->recommendation) && ! is_null($this->date_completed);
+    }
+
+    public function canBeUnassigned(): bool
+    {
+        return $this->status === ReviewerStatus::PENDING && is_null($this->date_confirmed);
+    }
+
+    public function canBeCanceled(): bool
+    {
+        return $this->status === ReviewerStatus::ACCEPTED;
+    }
+
+    public function scopeActiveAssignments(Builder $query): Builder
+    {
+        return $query->whereIn('status', [
+            ReviewerStatus::PENDING,
+            ReviewerStatus::ACCEPTED,
+        ]);
+    }
+
+    public function scopeSubmittedForDecision(Builder $query): Builder
+    {
+        return $query
+            ->where('status', ReviewerStatus::ACCEPTED)
+            ->whereNotNull('date_completed');
     }
 
     public function assignedFiles()

--- a/app/Models/Submission.php
+++ b/app/Models/Submission.php
@@ -338,7 +338,7 @@ class Submission extends Model implements HasMedia, HasPayment, Sortable
         $this->reviews()
             ->getQuery()
             ->with(['user'])
-            ->whereNotNull('date_completed')
+            ->submittedForDecision()
             ->get()
             ->each(function ($review, $key) use (&$message) {
                 $data = [

--- a/app/Panel/ScheduledConference/Livewire/Submissions/Components/ReviewerList.php
+++ b/app/Panel/ScheduledConference/Livewire/Submissions/Components/ReviewerList.php
@@ -440,13 +440,104 @@ class ReviewerList extends Component implements HasForms, HasTable
                             });
                             $action->success();
                         }),
+                    Action::make('unassign-reviewer')
+                        ->color('danger')
+                        ->authorize(fn () => auth()->user()->can('unassignReviewer', $this->record))
+                        ->icon('iconpark-deletethree-o')
+                        ->label(__('general.unassign_reviewer'))
+                        ->hidden(
+                            fn (Review $record) => ! $record->canBeUnassigned()
+                        )
+                        ->successNotificationTitle(__('general.reviewer_unassigned'))
+                        ->modalWidth('2xl')
+                        ->mountUsing(function (Form $form, Review $record) {
+                            $mailTemplate = DefaultMailTemplate::where('mailable', ReviewerCancelationMail::class)->first();
+                            $form->fill([
+                                'email' => $record->user->email,
+                                'subject' => $mailTemplate ? $mailTemplate->subject : '',
+                                'message' => $mailTemplate ? $mailTemplate->html_template : '',
+                            ]);
+                        })
+                        ->form([
+                            Fieldset::make('Notification')
+                                ->label(__('general.notification'))
+                                ->columns(1)
+                                ->schema([
+                                    TextInput::make('email')
+                                        ->label(__('general.email'))
+                                        ->disabled()
+                                        ->hidden(fn (Get $get) => $get('do-not-notify-cancelation'))
+                                        ->dehydrated(),
+                                    TextInput::make('subject')
+                                        ->label(__('general.subject'))
+                                        ->hidden(fn (Get $get) => $get('do-not-notify-cancelation'))
+                                        ->required()
+                                        ->columnSpanFull(),
+                                    TinyEditor::make('message')
+                                        ->label(__('general.message'))
+                                        ->minHeight(300)
+                                        ->profile('email')
+                                        ->hidden(fn (Get $get) => $get('do-not-notify-cancelation'))
+                                        ->columnSpanFull(),
+                                    Checkbox::make('do-not-notify-cancelation')
+                                        ->reactive()
+                                        ->label(__('general.dont_send_notification'))
+                                        ->columnSpanFull(),
+                                ]),
+                        ])
+                        ->action(function (Action $action, Review $record, array $data) {
+                            try {
+                                DB::beginTransaction();
+
+                                $record->assignedFiles()->delete();
+
+                                Log::make(
+                                    name: 'submission',
+                                    subject: $this->record,
+                                    description: __('general.submission_review_assign_canceled', [
+                                        'submissionId' => $this->record->getKey(),
+                                        'submissionName' => $this->record->getMeta('title'),
+                                        'name' => $record->user->full_name,
+                                    ]),
+                                )
+                                    ->by(auth()->user())
+                                    ->save();
+
+                                $record->delete();
+
+                                DB::commit();
+                            } catch (\Throwable $th) {
+                                DB::rollBack();
+
+                                $action->failureNotificationTitle($th->getMessage());
+                                $action->failure();
+
+                                return;
+                            }
+
+                            if (! data_get($data, 'do-not-notify-cancelation', false)) {
+                                try {
+                                    Mail::to($record->user->email)
+                                        ->send(
+                                            (new ReviewerCancelationMail($record))
+                                                ->subjectUsing($data['subject'])
+                                                ->contentUsing($data['message'])
+                                        );
+                                } catch (\Exception $e) {
+                                    $action->failureNotificationTitle(__('general.email_notification_was_not_delivered'));
+                                    $action->failure();
+                                }
+                            }
+
+                            $action->success();
+                        }),
                     Action::make('cancel-reviewer')
                         ->color('danger')
                         ->authorize(fn () => auth()->user()->can('cancelReviewer', $this->record))
                         ->icon('iconpark-deletethree-o')
                         ->label(__('general.cancel_reviewer'))
                         ->hidden(
-                            fn (Review $record) => $record->status == ReviewerStatus::CANCELED || $record->confirmed()
+                            fn (Review $record) => ! $record->canBeCanceled()
                         )
                         ->successNotificationTitle(__('general.reviewer_canceled'))
                         ->modalWidth('2xl')
@@ -540,7 +631,7 @@ class ReviewerList extends Component implements HasForms, HasTable
                         ])
                         ->action(function (Action $action, Review $record) {
                             $record->update([
-                                'status' => ReviewerStatus::PENDING,
+                                'status' => $record->date_confirmed ? ReviewerStatus::ACCEPTED : ReviewerStatus::PENDING,
                             ]);
                             $action->success();
                         }),

--- a/app/Panel/ScheduledConference/Pages/ReviewResult.php
+++ b/app/Panel/ScheduledConference/Pages/ReviewResult.php
@@ -47,12 +47,12 @@ class ReviewResult extends Page implements HasForms, HasTable
                         SubmissionStatus::Editing,
                         SubmissionStatus::Published,
                     ])
-                    ->whereHas('reviews', fn ($query) => $query->whereNotNull('date_completed'))
+                    ->whereHas('reviews', fn ($query) => $query->submittedForDecision())
                     ->withCount([
-                        'reviews',
-                        'reviews as completed_reviews_count' => fn ($query) => $query->whereNotNull('date_completed'),
+                        'reviews' => fn ($query) => $query->activeAssignments(),
+                        'reviews as completed_reviews_count' => fn ($query) => $query->submittedForDecision(),
                     ])
-                    ->withAvg(['reviews' => fn ($query) => $query->whereNotNull('date_completed')], 'score'),
+                    ->withAvg(['reviews' => fn ($query) => $query->submittedForDecision()], 'score'),
             )
             ->defaultSort('reviews_avg_score', 'desc')
             ->columns([

--- a/app/Panel/ScheduledConference/Resources/SubmissionResource.php
+++ b/app/Panel/ScheduledConference/Resources/SubmissionResource.php
@@ -51,8 +51,8 @@ class SubmissionResource extends Resource
         return parent::getEloquentQuery()
             ->withCount([
                 'editors',
-                'reviews',
-                'reviews as completed_reviews_count' => fn($query) => $query->whereNotNull('date_completed'),
+                'reviews' => fn($query) => $query->activeAssignments(),
+                'reviews as completed_reviews_count' => fn($query) => $query->submittedForDecision(),
             ])
             ->with(['meta', 'user', 'reviews', 'participants', 'editors'])
             ->orderBy('updated_at', 'desc');

--- a/app/Policies/SubmissionPolicy.php
+++ b/app/Policies/SubmissionPolicy.php
@@ -93,6 +93,15 @@ class SubmissionPolicy
         return $user->can('actAsEditor', $submission);
     }
 
+    public function unassignReviewer(User $user, Submission $submission)
+    {
+        if (in_array($submission->status, [SubmissionStatus::Declined, SubmissionStatus::Withdrawn, SubmissionStatus::Published, SubmissionStatus::OnPayment, SubmissionStatus::PaymentDeclined, SubmissionStatus::Queued])) {
+            return false;
+        }
+
+        return $user->can('actAsEditor', $submission);
+    }
+
     public function emailReviewer(User $user, Submission $submission)
     {
         if (in_array($submission->status, [SubmissionStatus::Declined, SubmissionStatus::Withdrawn, SubmissionStatus::Published, SubmissionStatus::OnPayment, SubmissionStatus::PaymentDeclined, SubmissionStatus::Queued])) {

--- a/lang/ar/general.php
+++ b/lang/ar/general.php
@@ -808,6 +808,8 @@ return [
     'send' => 'إرسال',
     'cancel_reviewer' => 'إلغاء المراجع',
     'reviewer_canceled' => 'تم إلغاء المراجع',
+    'unassign_reviewer' => 'Unassign Reviewer',
+    'reviewer_unassigned' => 'Reviewer assignment removed',
     'reinstate_reviewer' => 'إعادة تفعيل المراجع',
     'reviewer_reinstated' => 'تمت إعادة تفعيل المراجع',
     'user_not_found' => 'لم يتم العثور على المستخدم',

--- a/lang/en/general.php
+++ b/lang/en/general.php
@@ -827,6 +827,8 @@ return [
     'send' => 'Send',
     'cancel_reviewer' => 'Cancel Reviewer',
     'reviewer_canceled' => 'Reviewer canceled',
+    'unassign_reviewer' => 'Unassign Reviewer',
+    'reviewer_unassigned' => 'Reviewer assignment removed',
     'reinstate_reviewer' => 'Reinstate Reviewer',
     'reviewer_reinstated' => 'Reviewer Reinstated',
     'user_not_found' => 'User not Found',

--- a/lang/id/general.php
+++ b/lang/id/general.php
@@ -790,6 +790,8 @@ return [
     'send' => 'Kirim',
     'cancel_reviewer' => 'Batalkan Reviewer',
     'reviewer_canceled' => 'Reviewer dibatalkan',
+    'unassign_reviewer' => 'Batalkan Penugasan Reviewer',
+    'reviewer_unassigned' => 'Penugasan reviewer dihapus',
     'reinstate_reviewer' => 'Pulihkan Reviewer',
     'reviewer_reinstated' => 'Reviewer dipulihkan',
     'user_not_found' => 'Pengguna tidak ditemukan',

--- a/lang/ru/general.php
+++ b/lang/ru/general.php
@@ -780,6 +780,8 @@ return [
     'email_sent' => 'Письмо отправлено',
     'cancel_reviewer' => 'Отменить рецензента',
     'reviewer_canceled' => 'Рецензент отменён',
+    'unassign_reviewer' => 'Unassign Reviewer',
+    'reviewer_unassigned' => 'Reviewer assignment removed',
     'reinstate_reviewer' => 'Восстановить рецензента',
     'reviewer_reinstated' => 'Рецензент восстановлен',
     'user_not_found' => 'Пользователь не найден',

--- a/lang/sq/general.php
+++ b/lang/sq/general.php
@@ -792,6 +792,8 @@ return [
     'send' => 'Dërgo',
     'cancel_reviewer' => 'Anulo Rishikuesin',
     'reviewer_canceled' => 'Rishikuesi është anuluar',
+    'unassign_reviewer' => 'Unassign Reviewer',
+    'reviewer_unassigned' => 'Reviewer assignment removed',
     'reinstate_reviewer' => 'Rivendos Rishikuesin',
     'reviewer_reinstated' => 'Rishikuesi është rivendosur',
     'user_not_found' => 'Përdoruesi nuk u Gjet',

--- a/lang/uz/general.php
+++ b/lang/uz/general.php
@@ -780,6 +780,8 @@ return [
     'email_sent' => 'E-pochta yuborildi',
     'cancel_reviewer' => 'Retsenzentni bekor qilish',
     'reviewer_canceled' => 'Retsenzent bekor qilindi',
+    'unassign_reviewer' => 'Unassign Reviewer',
+    'reviewer_unassigned' => 'Reviewer assignment removed',
     'reinstate_reviewer' => 'Retsenzentni qayta faollashtirish',
     'reviewer_reinstated' => 'Retsenzent qayta tiklandi',
     'user_not_found' => 'Foydalanuvchi topilmadi',

--- a/tests/Feature/ReviewDecisionMetricsTest.php
+++ b/tests/Feature/ReviewDecisionMetricsTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Constants\ReviewerStatus;
+use App\Constants\SubmissionStatusRecommendation;
+use App\Models\Conference;
+use App\Models\Enums\SubmissionStage;
+use App\Models\Enums\SubmissionStatus;
+use App\Models\Enums\UserRole;
+use App\Models\Review;
+use App\Models\Role;
+use App\Models\ScheduledConference;
+use App\Models\Submission;
+use App\Models\Track;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ReviewDecisionMetricsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_decision_metrics_exclude_canceled_and_declined_reviews(): void
+    {
+        $context = $this->makeSubmissionContext();
+
+        $this->createReview($context['submission'], $context['acceptedReviewer'], [
+            'status' => ReviewerStatus::ACCEPTED,
+            'date_confirmed' => now()->subDays(2),
+            'date_completed' => now()->subDay(),
+            'recommendation' => SubmissionStatusRecommendation::ACCEPT,
+            'score' => 90,
+        ]);
+        $this->createReview($context['submission'], $context['canceledReviewer'], [
+            'status' => ReviewerStatus::CANCELED,
+            'date_confirmed' => now()->subDays(2),
+            'date_completed' => now()->subDay(),
+            'recommendation' => SubmissionStatusRecommendation::DECLINE,
+            'score' => 10,
+        ]);
+        $this->createReview($context['submission'], $context['declinedReviewer'], [
+            'status' => ReviewerStatus::DECLINED,
+            'date_confirmed' => now()->subDay(),
+        ]);
+        $this->createReview($context['submission'], $context['pendingReviewer'], [
+            'status' => ReviewerStatus::PENDING,
+            'date_confirmed' => null,
+        ]);
+
+        $metrics = Submission::query()
+            ->whereKey($context['submission']->getKey())
+            ->withCount([
+                'reviews as reviews_count' => fn ($query) => $query->activeAssignments(),
+                'reviews as completed_reviews_count' => fn ($query) => $query->submittedForDecision(),
+            ])
+            ->withAvg(['reviews' => fn ($query) => $query->submittedForDecision()], 'score')
+            ->firstOrFail();
+
+        $this->assertSame(2, $metrics->reviews_count);
+        $this->assertSame(1, $metrics->completed_reviews_count);
+        $this->assertSame(90.0, (float) $metrics->reviews_avg_score);
+    }
+
+    public function test_review_summary_email_uses_only_submitted_decision_reviews(): void
+    {
+        $context = $this->makeSubmissionContext();
+
+        $this->createReview($context['submission'], $context['acceptedReviewer'], [
+            'status' => ReviewerStatus::ACCEPTED,
+            'date_confirmed' => now()->subDays(2),
+            'date_completed' => now()->subDay(),
+            'recommendation' => SubmissionStatusRecommendation::ACCEPT,
+            'score' => 90,
+            'meta' => [
+                'review_mode' => Review::MODE_OPEN,
+                'review_for_author_editor' => 'Accepted review should be visible.',
+            ],
+        ]);
+        $this->createReview($context['submission'], $context['canceledReviewer'], [
+            'status' => ReviewerStatus::CANCELED,
+            'date_confirmed' => now()->subDays(2),
+            'date_completed' => now()->subDay(),
+            'recommendation' => SubmissionStatusRecommendation::DECLINE,
+            'score' => 10,
+            'meta' => [
+                'review_mode' => Review::MODE_OPEN,
+                'review_for_author_editor' => 'Canceled review should be hidden.',
+            ],
+        ]);
+
+        $message = $context['submission']->getReviewsEmailMessage();
+
+        $this->assertStringContainsString('Accepted review should be visible.', $message);
+        $this->assertStringNotContainsString('Canceled review should be hidden.', $message);
+    }
+
+    private function makeSubmissionContext(): array
+    {
+        $conference = Conference::factory()->create([
+            'path' => 'review-metrics-conference',
+        ]);
+        $scheduledConference = ScheduledConference::factory()->create([
+            'conference_id' => $conference->getKey(),
+            'path' => 'review-metrics-scheduled-conference',
+        ]);
+
+        app()->setCurrentConferenceId($conference->getKey());
+        app()->setCurrentScheduledConferenceId($scheduledConference->getKey());
+
+        $track = Track::withoutGlobalScopes()
+            ->where('scheduled_conference_id', $scheduledConference->getKey())
+            ->firstOrFail();
+
+        $author = User::factory()->create([
+            'email' => 'metrics-author@example.test',
+            'password' => 'password123456',
+        ]);
+        $reviewers = collect([
+            'acceptedReviewer' => 'accepted-reviewer@example.test',
+            'canceledReviewer' => 'canceled-reviewer@example.test',
+            'declinedReviewer' => 'declined-reviewer@example.test',
+            'pendingReviewer' => 'pending-reviewer@example.test',
+        ])->map(fn (string $email) => User::factory()->create([
+            'email' => $email,
+            'password' => 'password123456',
+        ]));
+
+        $reviewerRole = Role::withoutGlobalScopes()
+            ->where('name', UserRole::Reviewer->value)
+            ->where('conference_id', $conference->getKey())
+            ->where('scheduled_conference_id', $scheduledConference->getKey())
+            ->firstOrFail();
+
+        $reviewers->each(fn (User $reviewer) => $reviewer->assignRole($reviewerRole));
+
+        $submission = Submission::withoutGlobalScopes()->forceCreate([
+            'user_id' => $author->getKey(),
+            'conference_id' => $conference->getKey(),
+            'scheduled_conference_id' => $scheduledConference->getKey(),
+            'track_id' => $track->getKey(),
+            'stage' => SubmissionStage::PeerReview,
+            'status' => SubmissionStatus::OnReview,
+        ]);
+        $submission->setManyMeta([
+            'title' => 'Review metrics submission',
+        ]);
+
+        return [
+            'conference' => $conference,
+            'scheduledConference' => $scheduledConference,
+            'track' => $track,
+            'author' => $author,
+            'submission' => $submission,
+            ...$reviewers->all(),
+        ];
+    }
+
+    private function createReview(Submission $submission, User $reviewer, array $attributes = []): Review
+    {
+        $meta = $attributes['meta'] ?? [];
+        unset($attributes['meta']);
+
+        $review = Review::query()->create(array_merge([
+            'submission_id' => $submission->getKey(),
+            'user_id' => $reviewer->getKey(),
+            'status' => ReviewerStatus::PENDING,
+            'date_assigned' => now(),
+        ], $attributes));
+
+        if ($meta) {
+            $review->setManyMeta($meta);
+        }
+
+        return $review->refresh();
+    }
+}

--- a/tests/Feature/ReviewerAssignmentFlowTest.php
+++ b/tests/Feature/ReviewerAssignmentFlowTest.php
@@ -1,0 +1,297 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Constants\ReviewerStatus;
+use App\Constants\SubmissionFileCategory;
+use App\Constants\SubmissionStatusRecommendation;
+use App\Models\Conference;
+use App\Models\Enums\SubmissionStage;
+use App\Models\Enums\SubmissionStatus;
+use App\Models\Enums\UserRole;
+use App\Models\Permission;
+use App\Models\Review;
+use App\Models\Role;
+use App\Models\ScheduledConference;
+use App\Models\Submission;
+use App\Models\SubmissionFile;
+use App\Models\SubmissionFileType;
+use App\Models\Track;
+use App\Models\User;
+use App\Panel\ScheduledConference\Livewire\Submissions\Components\ReviewerList;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Route;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ReviewerAssignmentFlowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Route::get('/test/submissions/{record}/review', fn () => null)
+            ->name('filament.conference.resources.submissions.review');
+    }
+
+    public function test_pending_reviewer_can_be_unassigned_and_removed_from_assignment_history(): void
+    {
+        Mail::fake();
+
+        $context = $this->makeReviewerContext();
+        $pendingReview = $this->createReview($context['submission'], $context['reviewer'], [
+            'status' => ReviewerStatus::PENDING,
+            'date_confirmed' => null,
+        ]);
+        $assignedFile = $this->createAssignedFile($context['submission'], $pendingReview);
+
+        $this->actingAs($context['editor']);
+
+        Livewire::test(ReviewerList::class, ['record' => $context['submission']->refresh()])
+            ->assertTableActionVisible('unassign-reviewer', $pendingReview)
+            ->assertTableActionHidden('cancel-reviewer', $pendingReview)
+            ->callTableAction('unassign-reviewer', $pendingReview, data: [
+                'do-not-notify-cancelation' => true,
+            ]);
+
+        $this->assertDatabaseMissing('reviews', [
+            'id' => $pendingReview->getKey(),
+        ]);
+        $this->assertDatabaseMissing('reviewer_assigned_files', [
+            'id' => $assignedFile->getKey(),
+        ]);
+
+        $context['submission']->reviews()->create([
+            'user_id' => $context['reviewer']->getKey(),
+            'date_assigned' => now(),
+        ]);
+
+        $this->assertDatabaseHas('reviews', [
+            'submission_id' => $context['submission']->getKey(),
+            'user_id' => $context['reviewer']->getKey(),
+            'status' => ReviewerStatus::PENDING,
+        ]);
+    }
+
+    public function test_accepted_reviewer_can_be_canceled_without_losing_review_history(): void
+    {
+        Mail::fake();
+
+        $context = $this->makeReviewerContext();
+        $completedAt = now()->subDay()->startOfSecond();
+        $confirmedAt = now()->subDays(2)->startOfSecond();
+        $acceptedReview = $this->createReview($context['submission'], $context['reviewer'], [
+            'status' => ReviewerStatus::ACCEPTED,
+            'date_confirmed' => $confirmedAt,
+            'date_completed' => $completedAt,
+            'recommendation' => SubmissionStatusRecommendation::ACCEPT,
+            'score' => 88,
+            'quality' => 5,
+        ]);
+
+        $this->actingAs($context['editor']);
+
+        Livewire::test(ReviewerList::class, ['record' => $context['submission']->refresh()])
+            ->assertTableActionHidden('unassign-reviewer', $acceptedReview)
+            ->assertTableActionVisible('cancel-reviewer', $acceptedReview)
+            ->callTableAction('cancel-reviewer', $acceptedReview, data: [
+                'do-not-notify-cancelation' => true,
+            ]);
+
+        $acceptedReview->refresh();
+
+        $this->assertSame(ReviewerStatus::CANCELED, $acceptedReview->status);
+        $this->assertEquals($confirmedAt, $acceptedReview->date_confirmed);
+        $this->assertEquals($completedAt, $acceptedReview->date_completed);
+        $this->assertSame(SubmissionStatusRecommendation::ACCEPT, $acceptedReview->recommendation);
+        $this->assertSame(88, $acceptedReview->score);
+        $this->assertSame(5, $acceptedReview->quality);
+    }
+
+    public function test_declined_reviewer_stays_as_history_without_unassign_or_cancel_actions(): void
+    {
+        $context = $this->makeReviewerContext();
+        $declinedReview = $this->createReview($context['submission'], $context['reviewer'], [
+            'status' => ReviewerStatus::DECLINED,
+            'date_confirmed' => now()->subDay(),
+        ]);
+
+        $this->actingAs($context['editor']);
+
+        Livewire::test(ReviewerList::class, ['record' => $context['submission']->refresh()])
+            ->assertTableActionHidden('unassign-reviewer', $declinedReview)
+            ->assertTableActionHidden('cancel-reviewer', $declinedReview);
+
+        $this->assertDatabaseHas('reviews', [
+            'id' => $declinedReview->getKey(),
+            'status' => ReviewerStatus::DECLINED,
+        ]);
+    }
+
+    public function test_reinstating_canceled_reviewers_restores_their_original_commitment_state(): void
+    {
+        $context = $this->makeReviewerContext();
+        $acceptedCancellation = $this->createReview($context['submission'], $context['reviewer'], [
+            'status' => ReviewerStatus::CANCELED,
+            'date_confirmed' => now()->subDays(2),
+            'date_completed' => now()->subDay(),
+            'recommendation' => SubmissionStatusRecommendation::ACCEPT,
+            'score' => 80,
+        ]);
+        $legacyReviewer = User::factory()->create([
+            'email' => 'legacy-reviewer@example.test',
+            'password' => 'password123456',
+        ]);
+        $legacyReviewer->assignRole($context['reviewerRole']);
+        $legacyCancellation = $this->createReview($context['submission'], $legacyReviewer, [
+            'status' => ReviewerStatus::CANCELED,
+            'date_confirmed' => null,
+        ]);
+
+        $this->actingAs($context['editor']);
+
+        Livewire::test(ReviewerList::class, ['record' => $context['submission']->refresh()])
+            ->callTableAction('reinstate-reviewer', $acceptedCancellation)
+            ->callTableAction('reinstate-reviewer', $legacyCancellation);
+
+        $this->assertSame(ReviewerStatus::ACCEPTED, $acceptedCancellation->refresh()->status);
+        $this->assertSame(ReviewerStatus::PENDING, $legacyCancellation->refresh()->status);
+    }
+
+    private function makeReviewerContext(): array
+    {
+        $conference = Conference::factory()->create([
+            'path' => 'reviewer-flow-conference',
+        ]);
+        $scheduledConference = ScheduledConference::factory()->create([
+            'conference_id' => $conference->getKey(),
+            'path' => 'reviewer-flow-scheduled-conference',
+        ]);
+
+        app()->setCurrentConferenceId($conference->getKey());
+        app()->setCurrentScheduledConferenceId($scheduledConference->getKey());
+
+        $track = Track::withoutGlobalScopes()
+            ->where('scheduled_conference_id', $scheduledConference->getKey())
+            ->firstOrFail();
+
+        $author = User::factory()->create([
+            'email' => 'author@example.test',
+            'password' => 'password123456',
+        ]);
+        $editor = User::factory()->create([
+            'email' => 'editor@example.test',
+            'password' => 'password123456',
+        ]);
+        $reviewer = User::factory()->create([
+            'email' => 'reviewer@example.test',
+            'password' => 'password123456',
+        ]);
+
+        $editorRole = Role::withoutGlobalScopes()
+            ->where('name', UserRole::ScheduledConferenceEditor->value)
+            ->where('conference_id', $conference->getKey())
+            ->where('scheduled_conference_id', $scheduledConference->getKey())
+            ->firstOrFail();
+        $reviewerRole = Role::withoutGlobalScopes()
+            ->where('name', UserRole::Reviewer->value)
+            ->where('conference_id', $conference->getKey())
+            ->where('scheduled_conference_id', $scheduledConference->getKey())
+            ->firstOrFail();
+
+        Permission::query()->firstOrCreate([
+            'name' => 'Submission:reinstateReviewer',
+            'guard_name' => 'web',
+        ]);
+
+        $editor->assignRole($editorRole);
+        $reviewer->assignRole($reviewerRole);
+
+        $submission = Submission::withoutGlobalScopes()->forceCreate([
+            'user_id' => $author->getKey(),
+            'conference_id' => $conference->getKey(),
+            'scheduled_conference_id' => $scheduledConference->getKey(),
+            'track_id' => $track->getKey(),
+            'stage' => SubmissionStage::PeerReview,
+            'status' => SubmissionStatus::OnReview,
+        ]);
+        $submission->setManyMeta([
+            'title' => 'Reviewer assignment flow submission',
+        ]);
+        $submission->participants()->create([
+            'user_id' => $editor->getKey(),
+            'role_id' => $editorRole->getKey(),
+        ]);
+
+        return [
+            'conference' => $conference,
+            'scheduledConference' => $scheduledConference,
+            'track' => $track,
+            'author' => $author,
+            'editor' => $editor,
+            'reviewer' => $reviewer,
+            'reviewerRole' => $reviewerRole,
+            'submission' => $submission,
+        ];
+    }
+
+    private function createReview(Submission $submission, User $reviewer, array $attributes = []): Review
+    {
+        $meta = $attributes['meta'] ?? [];
+        unset($attributes['meta']);
+
+        $review = Review::query()->create(array_merge([
+            'submission_id' => $submission->getKey(),
+            'user_id' => $reviewer->getKey(),
+            'status' => ReviewerStatus::PENDING,
+            'date_assigned' => now(),
+        ], $attributes));
+
+        if ($meta) {
+            $review->setManyMeta($meta);
+        }
+
+        return $review->refresh();
+    }
+
+    private function createAssignedFile(Submission $submission, Review $review)
+    {
+        $submissionFileType = SubmissionFileType::withoutGlobalScopes()
+            ->where('scheduled_conference_id', $submission->scheduled_conference_id)
+            ->firstOrFail();
+
+        $mediaId = DB::table('media')->insertGetId([
+            'model_type' => Submission::class,
+            'model_id' => $submission->getKey(),
+            'collection_name' => 'paper-files',
+            'name' => 'paper',
+            'file_name' => 'paper.pdf',
+            'mime_type' => 'application/pdf',
+            'disk' => 'private-files',
+            'conversions_disk' => 'private-files',
+            'size' => 100,
+            'manipulations' => json_encode([]),
+            'custom_properties' => json_encode([]),
+            'generated_conversions' => json_encode([]),
+            'responsive_images' => json_encode([]),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $submissionFile = SubmissionFile::query()->create([
+            'submission_id' => $submission->getKey(),
+            'submission_file_type_id' => $submissionFileType->getKey(),
+            'media_id' => $mediaId,
+            'user_id' => $submission->user_id,
+            'category' => SubmissionFileCategory::PAPER_FILES,
+        ]);
+
+        return $review->assignedFiles()->create([
+            'submission_file_id' => $submissionFile->getKey(),
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- Split reviewer removal into pending unassign/delete and accepted cancel/history flows.
- Exclude canceled and declined reviews from decision score, completed count, active reviewer count, and generated review summaries.
- Add regression coverage for reviewer lifecycle actions and decision metrics.

## Test Plan
- php artisan test tests/Feature/ReviewerAssignmentFlowTest.php tests/Feature/ReviewDecisionMetricsTest.php
- php artisan test