### PR TITLE
Fix skipped review resend decision

### DIFF
--- a/app/Models/States/Submission/OnReviewSubmissionState.php
+++ b/app/Models/States/Submission/OnReviewSubmissionState.php
@@ -17,7 +17,17 @@ class OnReviewSubmissionState extends BaseSubmissionState
 
     public function acceptAbstract(): void
     {
-        // Repeating the current decision is allowed so editors can resend its notification.
+        if (! $this->submission->skipped_review) {
+            // Repeating the current decision is allowed so editors can resend its notification.
+            return;
+        }
+
+        SubmissionUpdateAction::run([
+            'skipped_review' => false,
+            'revision_required' => false,
+            'stage' => SubmissionStage::PeerReview,
+            'status' => SubmissionStatus::OnReview,
+        ], $this->submission);
     }
 
     public function acceptAndSkipReview(): void

--- a/tests/Feature/SubmissionDecisionActionsTest.php
+++ b/tests/Feature/SubmissionDecisionActionsTest.php
@@ -189,6 +189,60 @@ class SubmissionDecisionActionsTest extends TestCase
         $this->assertSame(SubmissionStatus::OnReview, $context['submission']->status);
     }
 
+    public function test_call_for_abstract_decision_clears_skipped_review_when_sending_a_skipped_submission_back_to_review(): void
+    {
+        Mail::fake();
+
+        $context = $this->makeEditorSubmissionContext([
+            'stage' => SubmissionStage::Presentation,
+            'status' => SubmissionStatus::OnPresentation,
+            'skipped_review' => true,
+        ]);
+
+        $this->actingAs($context['editor']);
+
+        Livewire::test(CallforAbstract::class, ['submission' => $context['submission']])
+            ->callAction('accept', data: $this->callForAbstractNotificationData([
+                'papers' => [],
+            ]));
+
+        $context['submission']->refresh();
+
+        $this->assertSame(SubmissionStage::PeerReview, $context['submission']->stage);
+        $this->assertSame(SubmissionStatus::OnReview, $context['submission']->status);
+        $this->assertFalse($context['submission']->skipped_review);
+
+        Livewire::test(PeerReview::class, ['submission' => $context['submission']])
+            ->assertDontSee(__('general.review_skipped'));
+    }
+
+    public function test_call_for_abstract_decision_clears_stale_skipped_review_when_resending_to_review(): void
+    {
+        Mail::fake();
+
+        $context = $this->makeEditorSubmissionContext([
+            'stage' => SubmissionStage::PeerReview,
+            'status' => SubmissionStatus::OnReview,
+            'skipped_review' => true,
+        ]);
+
+        $this->actingAs($context['editor']);
+
+        Livewire::test(CallforAbstract::class, ['submission' => $context['submission']])
+            ->callAction('accept', data: $this->callForAbstractNotificationData([
+                'papers' => [],
+            ]));
+
+        $context['submission']->refresh();
+
+        $this->assertSame(SubmissionStage::PeerReview, $context['submission']->stage);
+        $this->assertSame(SubmissionStatus::OnReview, $context['submission']->status);
+        $this->assertFalse($context['submission']->skipped_review);
+
+        Livewire::test(PeerReview::class, ['submission' => $context['submission']])
+            ->assertDontSee(__('general.review_skipped'));
+    }
+
     public function test_call_for_abstract_decision_can_skip_editing_submission_to_presentation(): void
     {
         Mail::fake();


### PR DESCRIPTION
## Summary
- Clear stale skipped review flags when resending a submission to review
- Keep normal repeat send-for-review behavior unchanged
- Add regression coverage for skipped submissions returning to review

## Test Plan
- rtk php artisan test tests/Feature/SubmissionDecisionActionsTest.php