### PR TITLE
Allow scheduled editors to login as users

### DIFF
--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -267,6 +267,7 @@ class Role extends Model
                     'User:disable',
                     'User:enable',
                     'User:invite',
+                    'User:loginAs',
                     'User:sendEmail',
                     'User:update',
                     'User:view',

--- a/tests/Unit/RoleDefaultPermissionsTest.php
+++ b/tests/Unit/RoleDefaultPermissionsTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Enums\UserRole;
+use App\Models\Role;
+use Tests\TestCase;
+
+class RoleDefaultPermissionsTest extends TestCase
+{
+    public function test_scheduled_conference_editor_can_login_as_users(): void
+    {
+        $this->assertContains(
+            'User:loginAs',
+            Role::getPermissionsForRole(UserRole::ScheduledConferenceEditor->value)
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add User:loginAs to the Scheduled Conference Editor default permissions.
- Add a regression test for the default permission mapping.

## Test Plan
- php artisan test tests/Unit/RoleDefaultPermissionsTest.php