### PR TITLE
Remove revision upload instruction from table

### DIFF
--- a/app/Panel/ScheduledConference/Livewire/Submissions/Components/Files/RevisionFiles.php
+++ b/app/Panel/ScheduledConference/Livewire/Submissions/Components/Files/RevisionFiles.php
@@ -12,12 +12,9 @@ class RevisionFiles extends SubmissionFilesTable
 
     protected string $tableHeading;
 
-    protected string $tableDescription;
-
     public function __construct()
     {
         $this->tableHeading = __('general.revisions');
-        $this->tableDescription = __('general.upload_your_reviews_files_here');
     }
 
     public function isViewOnly(): bool

--- a/tests/Unit/RevisionFilesTableTest.php
+++ b/tests/Unit/RevisionFilesTableTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Panel\ScheduledConference\Livewire\Submissions\Components\Files\RevisionFiles;
+use Tests\TestCase;
+
+class RevisionFilesTableTest extends TestCase
+{
+    public function test_revisions_table_has_no_upload_instruction_description(): void
+    {
+        $this->assertSame('', (new RevisionFiles())->tableDescription());
+    }
+}


### PR DESCRIPTION
## Summary
- Remove the upload instruction description from the Revisions table.
- Add a regression test so the table description remains empty.

## Test Plan
- php artisan test tests/Unit/RevisionFilesTableTest.php