### PR TITLE
Exclude admin from operational notifications

### DIFF
--- a/app/Classes/ManualPaymentPlugin.php
+++ b/app/Classes/ManualPaymentPlugin.php
@@ -3,13 +3,13 @@
 namespace App\Classes;
 
 use App\Facades\Hook;
+use App\Forms\Components\SpatieMediaLibraryFileUpload;
 use App\Mail\Templates\UserPayPaymentMail;
 use App\Models\Enums\UserRole;
 use App\Models\Payment;
-use App\Models\User;
+use App\Services\Notifications\OperationalNotificationRecipients;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Placeholder;
-use App\Forms\Components\SpatieMediaLibraryFileUpload;
 use Filament\Infolists\Components\Actions\Action as InfolistAction;
 use Filament\Infolists\Components\Section;
 use Filament\Infolists\Components\TextEntry;
@@ -34,11 +34,11 @@ class ManualPaymentPlugin extends Plugin
                         Placeholder::make('manual_payment_instructions')
                             ->hiddenLabel()
                             ->label('Payment Instructions')
-                            ->content(fn() => new HtmlString(app()->getCurrentScheduledConference()->getMeta('manual_payment_instructions')))
-                            ->visible(fn() => app()->getCurrentScheduledConference()->getMeta('manual_payment_instructions')),
+                            ->content(fn () => new HtmlString(app()->getCurrentScheduledConference()->getMeta('manual_payment_instructions')))
+                            ->visible(fn () => app()->getCurrentScheduledConference()->getMeta('manual_payment_instructions')),
                         Placeholder::make('amount')
                             ->label('Amount')
-                            ->content(fn(Payment $record) => $record->getFormattedFee()),
+                            ->content(fn (Payment $record) => $record->getFormattedFee()),
                         SpatieMediaLibraryFileUpload::make('payment_proof')
                             ->label('Payment Proof')
                             ->required()
@@ -48,10 +48,10 @@ class ManualPaymentPlugin extends Plugin
                     ])
                     ->action(function (Action $action, array $data, Payment $record) {
                         $record->touch();
-                        
-                        User::role([UserRole::Admin, UserRole::ConferenceManager, UserRole::ScheduledConferenceEditor])
-                            ->lazy()
-                            ->each(fn($user) => Mail::to($user->email)->send(new UserPayPaymentMail($record)));
+
+                        app(OperationalNotificationRecipients::class)
+                            ->forRoles([UserRole::ConferenceManager, UserRole::ScheduledConferenceEditor])
+                            ->each(fn ($user) => Mail::to($user->email)->send(new UserPayPaymentMail($record)));
 
                         $action->successNotificationTitle('Submit success.');
                         $action->success();
@@ -62,13 +62,13 @@ class ManualPaymentPlugin extends Plugin
 
             Hook::add('PaymentManager::getPaymentMethodInfolist', function ($hookName, &$schemas) {
                 $schemas[] = Section::make(app()->getCurrentScheduledConference()->getMeta('manual_payment_name') ?? 'Manual Payment')
-                    ->visible(fn($record) => $record->hasMedia('manual_payment_proof'))
+                    ->visible(fn ($record) => $record->hasMedia('manual_payment_proof'))
                     ->schema([
                         TextEntry::make('payment_proof')
                             ->state('Download')
                             ->color('primary')
                             ->action(
-                                InfolistAction::make('download')->action(fn($record) => $record->getFirstMedia('manual_payment_proof'))
+                                InfolistAction::make('download')->action(fn ($record) => $record->getFirstMedia('manual_payment_proof'))
                             ),
                     ]);
 

--- a/app/Panel/ScheduledConference/Livewire/Wizards/SubmissionWizard/Steps/ReviewStep.php
+++ b/app/Panel/ScheduledConference/Livewire/Wizards/SubmissionWizard/Steps/ReviewStep.php
@@ -11,6 +11,7 @@ use App\Models\User;
 use App\Notifications\NewSubmission;
 use App\Panel\ScheduledConference\Livewire\Wizards\SubmissionWizard\Contracts\HasWizardStep;
 use App\Panel\ScheduledConference\Resources\SubmissionResource;
+use App\Services\Notifications\OperationalNotificationRecipients;
 use Filament\Actions\Action;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
@@ -47,7 +48,7 @@ class ReviewStep extends Component implements HasActions, HasForms, HasWizardSte
             })
             ->modalSubmitActionLabel(__('general.submit'))
             ->successNotificationTitle(__('general.abstract_submitted_wait'))
-            ->successRedirectUrl(fn(): string => SubmissionResource::getUrl('complete', ['record' => $this->record]))
+            ->successRedirectUrl(fn (): string => SubmissionResource::getUrl('complete', ['record' => $this->record]))
             ->action(function (Action $action) {
                 try {
                     DB::beginTransaction();
@@ -65,11 +66,11 @@ class ReviewStep extends Component implements HasActions, HasForms, HasWizardSte
                             ->role(UserRole::TrackEditor)
                             ->whereIn('id', $this->record->track->getMeta('track_editors'))
                             ->lazy()
-                            ->each(fn($user) => SubmissionAssignParticipant::run($this->record, $user->getKey(), $trackRole->getKey()));
+                            ->each(fn ($user) => SubmissionAssignParticipant::run($this->record, $user->getKey(), $trackRole->getKey()));
                     } else {
-                        User::role([UserRole::Admin->value, UserRole::ConferenceManager->value])
-                            ->lazy()
-                            ->each(fn($user) => $user->notify(new NewSubmission($this->record)));
+                        app(OperationalNotificationRecipients::class)
+                            ->forRoles([UserRole::ConferenceManager])
+                            ->each(fn ($user) => $user->notify(new NewSubmission($this->record)));
                     }
 
                     $this->record->touch();

--- a/app/Panel/ScheduledConference/Pages/ParticipantRegistration.php
+++ b/app/Panel/ScheduledConference/Pages/ParticipantRegistration.php
@@ -8,9 +8,9 @@ use App\Models\Participant;
 use App\Models\Payment;
 use App\Models\PaymentFee;
 use App\Models\PaymentFormItem;
-use App\Models\User;
 use App\Notifications\ParticipantPayment;
 use App\Notifications\ParticipantRegistered;
+use App\Services\Notifications\OperationalNotificationRecipients;
 use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\Radio;
 use Filament\Forms\Components\Section;
@@ -198,8 +198,8 @@ class ParticipantRegistration extends Page implements HasForms
                 $payment->markInvoiceAsSent();
             }
 
-            User::role([UserRole::Admin->value, UserRole::ConferenceManager->value])
-                ->lazy()
+            app(OperationalNotificationRecipients::class)
+                ->forRoles([UserRole::ConferenceManager])
                 ->each(fn ($user) => $user->notify(new ParticipantRegistered($participant)));
 
             DB::commit();

--- a/app/Panel/ScheduledConference/Resources/SubmissionResource/Pages/ViewSubmission.php
+++ b/app/Panel/ScheduledConference/Resources/SubmissionResource/Pages/ViewSubmission.php
@@ -35,6 +35,7 @@ use App\Panel\ScheduledConference\Livewire\Submissions\Presentation;
 use App\Panel\ScheduledConference\Pages\PaymentDetail;
 use App\Panel\ScheduledConference\Resources\SubmissionResource;
 use App\Services\Billing\SubmissionBillingNotifier;
+use App\Services\Notifications\OperationalNotificationRecipients;
 use Awcodes\Shout\Components\ShoutEntry;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Checkbox;
@@ -308,21 +309,16 @@ class ViewSubmission extends Page implements HasForms, HasInfolists
                     );
 
                     try {
-                        // Currently using admin, next is admin removed only managers
-                        User::whereHas(
-                            'roles',
-                            fn ($query) => $query->whereIn('name', [UserRole::Admin->value, UserRole::ConferenceManager->value])
-                        )
-                            ->get()
-                            ->each(
-                                fn ($manager) => $manager->notify(new SubmissionWithdrawRequested($this->record))
-                            );
+                        $recipients = app(OperationalNotificationRecipients::class);
 
-                        $this
-                            ->record
-                            ->getEditors()
-                            ->each(function (User $editor) {
-                                $editor->notify(new SubmissionWithdrawRequested($this->record));
+                        $recipients
+                            ->uniqueUsers(
+                                $recipients
+                                    ->forRoles([UserRole::ConferenceManager])
+                                    ->merge($this->record->getEditors())
+                            )
+                            ->each(function (User $user) {
+                                $user->notify(new SubmissionWithdrawRequested($this->record));
                             });
                     } catch (\Exception $e) {
                         $action->failureNotificationTitle(__('general.failed_send_notification'));

--- a/app/Services/Notifications/OperationalNotificationRecipients.php
+++ b/app/Services/Notifications/OperationalNotificationRecipients.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Services\Notifications;
+
+use App\Models\Enums\UserRole;
+use App\Models\User;
+use Illuminate\Support\Collection;
+
+class OperationalNotificationRecipients
+{
+    /**
+     * @param  array<int, UserRole|string>  $roles
+     * @return Collection<int, User>
+     */
+    public function forRoles(array $roles): Collection
+    {
+        $roleNames = collect($roles)
+            ->map(fn (UserRole|string $role): string => $role instanceof UserRole ? $role->value : $role)
+            ->reject(fn (string $role): bool => $role === UserRole::Admin->value)
+            ->unique()
+            ->values();
+
+        if ($roleNames->isEmpty()) {
+            return collect();
+        }
+
+        return User::query()
+            ->whereHas('roles', fn ($query) => $query->whereIn('name', $roleNames))
+            ->get()
+            ->unique(fn (User $user): int|string => $user->getKey())
+            ->values();
+    }
+
+    /**
+     * @param  iterable<User>  $users
+     * @return Collection<int, User>
+     */
+    public function uniqueUsers(iterable $users): Collection
+    {
+        return collect($users)
+            ->filter(fn ($user): bool => $user instanceof User && filled($user->getKey()))
+            ->unique(fn (User $user): int|string => $user->getKey())
+            ->values();
+    }
+}

--- a/tests/Feature/OperationalNotificationRecipientsTest.php
+++ b/tests/Feature/OperationalNotificationRecipientsTest.php
@@ -1,0 +1,274 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Managers\PaymentManager;
+use App\Models\Conference;
+use App\Models\Enums\SubmissionStage;
+use App\Models\Enums\SubmissionStatus;
+use App\Models\Enums\UserRole;
+use App\Models\PaymentFee;
+use App\Models\Role;
+use App\Models\ScheduledConference;
+use App\Models\Submission;
+use App\Models\Track;
+use App\Models\User;
+use App\Notifications\NewSubmission;
+use App\Notifications\ParticipantRegistered;
+use App\Notifications\SubmissionWithdrawRequested;
+use App\Panel\ScheduledConference\Livewire\Wizards\SubmissionWizard\Steps\ReviewStep;
+use App\Panel\ScheduledConference\Pages\ParticipantRegistration;
+use App\Panel\ScheduledConference\Resources\SubmissionResource\Pages\ViewSubmission;
+use App\Services\Notifications\OperationalNotificationRecipients;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Route;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class OperationalNotificationRecipientsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Conference $conference;
+
+    private ScheduledConference $scheduledConference;
+
+    private Track $track;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Route::get('/test/submissions', fn () => null)
+            ->name('filament.conference.resources.submissions.index');
+        Route::get('/test/submissions/{record}', fn () => null)
+            ->name('filament.conference.resources.submissions.view');
+        Route::get('/test/submissions/complete/{record}', fn () => null)
+            ->name('filament.conference.resources.submissions.complete');
+        Route::get('/test/payments/{record}', fn () => null)
+            ->name('filament.conference.pages.payment-detail');
+
+        $this->conference = Conference::factory()->create([
+            'path' => 'operational-notifications',
+        ]);
+        $this->scheduledConference = ScheduledConference::factory()->create([
+            'conference_id' => $this->conference->getKey(),
+            'path' => 'operational-notifications-2026',
+        ]);
+
+        app()->setCurrentConferenceId($this->conference->getKey());
+        app()->setCurrentScheduledConferenceId($this->scheduledConference->getKey());
+
+        $this->track = Track::withoutGlobalScopes()->create([
+            'scheduled_conference_id' => $this->scheduledConference->getKey(),
+            'title' => 'General Track',
+            'abbreviation' => 'GEN',
+            'is_active' => true,
+        ]);
+    }
+
+    public function test_operational_recipients_exclude_admin_role_targets(): void
+    {
+        $admin = $this->userWithRole(UserRole::Admin, 'admin@example.test');
+        $manager = $this->userWithRole(UserRole::ConferenceManager, 'manager@example.test');
+
+        $recipientIds = app(OperationalNotificationRecipients::class)
+            ->forRoles([UserRole::Admin, UserRole::ConferenceManager])
+            ->pluck('id');
+
+        $this->assertFalse($recipientIds->contains($admin->getKey()));
+        $this->assertTrue($recipientIds->contains($manager->getKey()));
+    }
+
+    public function test_operational_recipients_accept_enum_and_string_roles(): void
+    {
+        $manager = $this->userWithRole(UserRole::ConferenceManager, 'manager@example.test');
+
+        $enumRecipientIds = app(OperationalNotificationRecipients::class)
+            ->forRoles([UserRole::ConferenceManager])
+            ->pluck('id')
+            ->all();
+
+        $stringRecipientIds = app(OperationalNotificationRecipients::class)
+            ->forRoles([UserRole::ConferenceManager->value])
+            ->pluck('id')
+            ->all();
+
+        $this->assertSame([$manager->getKey()], $enumRecipientIds);
+        $this->assertSame($enumRecipientIds, $stringRecipientIds);
+    }
+
+    public function test_operational_recipients_can_dedupe_merged_user_lists(): void
+    {
+        $manager = $this->userWithRole(UserRole::ConferenceManager, 'manager@example.test');
+        $editor = $this->userWithRole(UserRole::ScheduledConferenceEditor, 'editor@example.test');
+
+        $recipientIds = app(OperationalNotificationRecipients::class)
+            ->uniqueUsers([$manager, $editor, $manager, $editor])
+            ->pluck('id')
+            ->all();
+
+        $this->assertSame([$manager->getKey(), $editor->getKey()], $recipientIds);
+    }
+
+    public function test_participant_registration_notifies_manager_but_not_admin(): void
+    {
+        $admin = $this->userWithRole(UserRole::Admin, 'admin@example.test');
+        $manager = $this->userWithRole(UserRole::ConferenceManager, 'manager@example.test');
+        $participant = $this->userWithRole(UserRole::Participant, 'participant@example.test');
+        $paymentFee = $this->createPaymentFee(PaymentManager::TYPE_PARTICIPANT_FEE);
+
+        $this->scheduledConference->setMeta('participant_payment', true);
+        Notification::fake();
+
+        $this->actingAs($participant);
+
+        Livewire::test(ParticipantRegistration::class)
+            ->set('formData.given_name', 'Participant')
+            ->set('formData.family_name', 'Tester')
+            ->set('formData.payment_fee_id', $paymentFee->getKey())
+            ->call('submit');
+
+        Notification::assertSentTo($manager, ParticipantRegistered::class);
+        Notification::assertNotSentTo($admin, ParticipantRegistered::class);
+    }
+
+    public function test_new_submission_fallback_notifies_manager_but_not_admin(): void
+    {
+        $admin = $this->userWithRole(UserRole::Admin, 'admin@example.test');
+        $manager = $this->userWithRole(UserRole::ConferenceManager, 'manager@example.test');
+        $author = $this->userWithRole(UserRole::Author, 'author@example.test');
+        $submission = $this->createSubmission($author, [
+            'stage' => SubmissionStage::Wizard,
+            'status' => SubmissionStatus::Incomplete,
+        ]);
+
+        Notification::fake();
+
+        $this->actingAs($author);
+
+        Livewire::test(ReviewStep::class, ['record' => $submission])
+            ->callAction('submitAction');
+
+        Notification::assertSentTo($manager, NewSubmission::class);
+        Notification::assertNotSentTo($admin, NewSubmission::class);
+    }
+
+    public function test_withdrawal_request_notifies_unique_operational_recipients_but_not_admin(): void
+    {
+        $admin = $this->userWithRole(UserRole::Admin, 'admin@example.test');
+        $manager = $this->userWithRole(UserRole::ConferenceManager, 'manager@example.test');
+        $author = $this->userWithRole(UserRole::Author, 'author@example.test');
+        $submission = $this->createSubmission($author, [
+            'stage' => SubmissionStage::PeerReview,
+            'status' => SubmissionStatus::OnReview,
+        ]);
+        $submission->participants()->create([
+            'user_id' => $manager->getKey(),
+            'role_id' => $this->role(UserRole::ConferenceManager)->getKey(),
+        ]);
+
+        Notification::fake();
+
+        $this->actingAs($author);
+
+        $this->callViewSubmissionHeaderAction($submission, 'request_withdraw', [
+            'reason' => 'Author requested withdrawal.',
+        ]);
+
+        $this->assertCount(1, Notification::sent($manager, SubmissionWithdrawRequested::class));
+        Notification::assertNotSentTo($admin, SubmissionWithdrawRequested::class);
+    }
+
+    private function role(UserRole $role): Role
+    {
+        $attributes = [
+            'name' => $role->value,
+            'guard_name' => 'web',
+            'conference_id' => 0,
+            'scheduled_conference_id' => 0,
+        ];
+
+        if ($role === UserRole::ConferenceManager) {
+            $attributes['conference_id'] = $this->conference->getKey();
+        }
+
+        if (in_array($role, UserRole::scheduledConferenceRoles(), true)) {
+            $attributes['conference_id'] = $this->conference->getKey();
+            $attributes['scheduled_conference_id'] = $this->scheduledConference->getKey();
+        }
+
+        return Role::withoutGlobalScopes()->firstOrCreate($attributes);
+    }
+
+    private function userWithRole(UserRole $role, string $email): User
+    {
+        $user = User::factory()->create([
+            'email' => $email,
+            'password' => 'password123456',
+        ]);
+
+        $user->assignRole($this->role($role));
+
+        return $user->refresh();
+    }
+
+    /**
+     * @param  array<string, mixed>  $state
+     */
+    private function createSubmission(User $author, array $state): Submission
+    {
+        $submission = Submission::withoutGlobalScopes()->forceCreate([
+            'user_id' => $author->getKey(),
+            'conference_id' => $this->conference->getKey(),
+            'scheduled_conference_id' => $this->scheduledConference->getKey(),
+            'track_id' => $this->track->getKey(),
+            ...$state,
+        ]);
+        $submission->setMeta('title', 'Operational Notification Submission');
+
+        return $submission->refresh();
+    }
+
+    private function createPaymentFee(int $type): PaymentFee
+    {
+        return PaymentFee::withoutGlobalScopes()->create([
+            'conference_id' => $this->conference->getKey(),
+            'scheduled_conference_id' => $this->scheduledConference->getKey(),
+            'name' => 'Registration Fee',
+            'type' => $type,
+            'amount' => 100,
+            'currency' => 'usd',
+            'is_active' => true,
+            'is_public' => true,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function callViewSubmissionHeaderAction(Submission $submission, string $actionName, array $data): void
+    {
+        $page = app(ViewSubmission::class);
+        $page->record = $submission;
+
+        $method = new \ReflectionMethod($page, 'getHeaderActions');
+        $method->setAccessible(true);
+
+        $action = collect($method->invoke($page))
+            ->first(fn ($action): bool => $action->getName() === $actionName);
+
+        $this->assertNotNull($action);
+
+        try {
+            $action
+                ->livewire($page)
+                ->call(['data' => $data]);
+        } catch (\Symfony\Component\Routing\Exception\RouteNotFoundException $exception) {
+            if (! str_contains($exception->getMessage(), 'filament.conference.resources.submissions.view')) {
+                throw $exception;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add an operational notification recipient helper that excludes Admin as a broadcast target and de-duplicates merged user lists.
- Update manual payment, new submission fallback, participant registration, and withdrawal request notifications to target operational roles without broadcasting to Admin.
- Add regression coverage for admin exclusion and unique recipient delivery.

## Root Cause
Operational notification call sites explicitly included `UserRole::Admin`, so admin-role users received workflow emails/database notifications intended for conference operators.

## Validation
- `rtk php artisan test`
- `rtk ./vendor/bin/pint --test app/Services/Notifications/OperationalNotificationRecipients.php app/Classes/ManualPaymentPlugin.php app/Panel/ScheduledConference/Livewire/Wizards/SubmissionWizard/Steps/ReviewStep.php app/Panel/ScheduledConference/Pages/ParticipantRegistration.php app/Panel/ScheduledConference/Resources/SubmissionResource/Pages/ViewSubmission.php tests/Feature/OperationalNotificationRecipientsTest.php`