### PR TITLE
Gate scheduled registration setting

### DIFF
--- a/app/Frontend/ScheduledConference/Pages/Login.php
+++ b/app/Frontend/ScheduledConference/Pages/Login.php
@@ -49,7 +49,9 @@ class Login extends WebsiteLogin implements HasActions, HasForms
     {
         return [
             'resetPasswordUrl' => route('livewirePageGroup.scheduledConference.pages.reset-password'),
-            'registerUrl' => route('livewirePageGroup.scheduledConference.pages.register'),
+            'registerUrl' => $this->isRegistrationAllowed()
+                ? route('livewirePageGroup.scheduledConference.pages.register')
+                : null,
         ];
     }
 
@@ -140,7 +142,13 @@ class Login extends WebsiteLogin implements HasActions, HasForms
         return Action::make('register')
             ->link()
             ->label(__('general.register'))
+            ->visible(fn (): bool => $this->isRegistrationAllowed())
             ->url(route('livewirePageGroup.scheduledConference.pages.register'));
+    }
+
+    protected function isRegistrationAllowed(): bool
+    {
+        return (bool) app()->getCurrentScheduledConference()?->getMeta('allow_registration');
     }
 
     protected function getRateLimitedNotification(TooManyRequestsException $exception): ?Notification

--- a/app/Frontend/ScheduledConference/Pages/Register.php
+++ b/app/Frontend/ScheduledConference/Pages/Register.php
@@ -65,10 +65,6 @@ class Register extends Page implements HasActions, HasForms
 
     public function mount()
     {
-        if (! $this->isRegistrationAllowed()) {
-            abort(403);
-        }
-
         if (Filament::auth()->check()) {
             $this->redirect($this->getRedirectUrl(), navigate: false);
 
@@ -320,7 +316,12 @@ class Register extends Page implements HasActions, HasForms
     public function register()
     {
         if (! $this->isRegistrationAllowed()) {
-            abort(403);
+            Notification::make()
+                ->title(__('general.registration_closed'))
+                ->warning()
+                ->send();
+
+            return null;
         }
 
         try {

--- a/app/Frontend/ScheduledConference/Pages/Register.php
+++ b/app/Frontend/ScheduledConference/Pages/Register.php
@@ -65,6 +65,10 @@ class Register extends Page implements HasActions, HasForms
 
     public function mount()
     {
+        if (! $this->isRegistrationAllowed()) {
+            abort(403);
+        }
+
         if (Filament::auth()->check()) {
             $this->redirect($this->getRedirectUrl(), navigate: false);
 
@@ -315,7 +319,7 @@ class Register extends Page implements HasActions, HasForms
 
     public function register()
     {
-        if (! app()->getCurrentScheduledConference()->getMeta('allow_registration')) {
+        if (! $this->isRegistrationAllowed()) {
             abort(403);
         }
 
@@ -361,9 +365,14 @@ class Register extends Page implements HasActions, HasForms
 
         return [
             'loginUrl' => app()->getLoginUrl(),
-            'allowRegistration' => $scheduledConference->getMeta('allow_registration'),
+            'allowRegistration' => $this->isRegistrationAllowed(),
             'scheduledConference' => $scheduledConference,
         ];
+    }
+
+    protected function isRegistrationAllowed(): bool
+    {
+        return (bool) app()->getCurrentScheduledConference()->getMeta('allow_registration');
     }
 
     public function getBreadcrumbs(): array

--- a/app/Models/ScheduledConference.php
+++ b/app/Models/ScheduledConference.php
@@ -376,7 +376,7 @@ class ScheduledConference extends Model implements HasAvatar, HasMedia, HasName
 
     public function isParticipantRegistrationEnabled(): bool
     {
-        return $this->isParticipantPaymentEnabled();
+        return $this->getMeta('allow_registration') && $this->isParticipantPaymentEnabled();
     }
 
     public function getPaymentOpenedAt(): ?Carbon

--- a/app/Panel/ScheduledConference/Pages/ParticipantRegistration.php
+++ b/app/Panel/ScheduledConference/Pages/ParticipantRegistration.php
@@ -145,6 +145,17 @@ class ParticipantRegistration extends Page implements HasForms
 
     public function submit()
     {
+        $scheduledConference = app()->getCurrentScheduledConference()?->fresh();
+
+        if (! $scheduledConference?->isParticipantRegistrationEnabled()) {
+            Notification::make()
+                ->warning()
+                ->title(__('general.registration_closed'))
+                ->send();
+
+            return null;
+        }
+
         $data = $this->form->getState();
         $paymentFormResponses = PaymentFormItem::filterOutUploadResponses(data_get($data, 'form_responses'));
 

--- a/resources/views/frontend/scheduledConference/pages/register.blade.php
+++ b/resources/views/frontend/scheduledConference/pages/register.blade.php
@@ -24,11 +24,17 @@
             </h1>
         </header>
 
-        <x-filament-panels::form wire:submit="register">
-            {{ $this->form }}
+        @if ($allowRegistration)
+            <x-filament-panels::form wire:submit="register">
+                {{ $this->form }}
 
-            <x-filament-panels::form.actions :actions="$this->getFormActions()" :fullWidth="true" />
-        </x-filament-panels::form>
+                <x-filament-panels::form.actions :actions="$this->getFormActions()" :fullWidth="true" />
+            </x-filament-panels::form>
+        @else
+            <div class="rounded-xl bg-gray-50 px-4 py-3 text-center text-sm font-medium text-gray-700 ring-1 ring-gray-950/5 dark:bg-white/5 dark:text-gray-200 dark:ring-white/10">
+                {{ __('general.registration_closed') }}
+            </div>
+        @endif
     </section>
 
     <x-filament-actions::modals />

--- a/tests/Feature/OperationalNotificationRecipientsTest.php
+++ b/tests/Feature/OperationalNotificationRecipientsTest.php
@@ -134,6 +134,37 @@ class OperationalNotificationRecipientsTest extends TestCase
         Notification::assertNotSentTo($admin, ParticipantRegistered::class);
     }
 
+    public function test_participant_registration_submit_is_ignored_when_registration_is_disabled(): void
+    {
+        $manager = $this->userWithRole(UserRole::ConferenceManager, 'manager-closed@example.test');
+        $participant = $this->userWithRole(UserRole::Participant, 'closed-participant@example.test');
+        $paymentFee = $this->createPaymentFee(PaymentManager::TYPE_PARTICIPANT_FEE);
+
+        $this->scheduledConference->setManyMeta([
+            'allow_registration' => true,
+            'participant_payment' => true,
+        ]);
+        Notification::fake();
+
+        $this->actingAs($participant);
+
+        $component = Livewire::test(ParticipantRegistration::class)
+            ->set('formData.given_name', 'Closed')
+            ->set('formData.family_name', 'Participant')
+            ->set('formData.payment_fee_id', $paymentFee->getKey());
+
+        $this->scheduledConference->setMeta('allow_registration', false);
+
+        $component
+            ->call('submit')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseMissing('participants', [
+            'email' => 'closed-participant@example.test',
+        ]);
+        Notification::assertNotSentTo($manager, ParticipantRegistered::class);
+    }
+
     public function test_new_submission_fallback_notifies_manager_but_not_admin(): void
     {
         $admin = $this->userWithRole(UserRole::Admin, 'admin@example.test');

--- a/tests/Feature/ScheduledConferenceAccessFlowTest.php
+++ b/tests/Feature/ScheduledConferenceAccessFlowTest.php
@@ -10,6 +10,7 @@ use App\Models\ScheduledConference;
 use App\Models\User;
 use App\Panel\Conference\Resources\UserResource;
 use App\Panel\ScheduledConference\Pages\Dashboard;
+use App\Panel\ScheduledConference\Pages\ParticipantRegistration;
 use App\Policies\UserPolicy;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
@@ -80,6 +81,37 @@ class ScheduledConferenceAccessFlowTest extends TestCase
         app()->setCurrentScheduledConferenceId($enabledScheduledConference->getKey());
 
         $this->assertContains(UserRole::Participant->name, UserRole::getAllowedSelfAssignRoleNames());
+    }
+
+    public function test_participant_registration_page_requires_registration_to_be_allowed(): void
+    {
+        $conference = Conference::query()->create([
+            'name' => 'Test Conference',
+            'path' => 'test-conference',
+        ]);
+
+        $scheduledConference = ScheduledConference::query()->create([
+            'conference_id' => $conference->getKey(),
+            'title' => 'Test Scheduled Conference',
+            'path' => 'test',
+        ]);
+        $scheduledConference->setManyMeta([
+            'allow_registration' => false,
+            'participant_payment' => true,
+        ]);
+
+        app()->setCurrentConferenceId($conference->getKey());
+        app()->setCurrentScheduledConferenceId($scheduledConference->getKey());
+
+        $participant = User::factory()->create([
+            'email' => 'participant-access@example.test',
+            'password' => Hash::make('password12345'),
+        ]);
+        $participant->assignRole($this->createScheduledConferenceRole(UserRole::Participant, $conference, $scheduledConference));
+
+        $this->actingAs($participant);
+
+        $this->assertFalse(ParticipantRegistration::canAccess());
     }
 
     public function test_scheduled_conference_registration_redirect_url_points_to_panel_dashboard(): void
@@ -183,6 +215,19 @@ class ScheduledConferenceAccessFlowTest extends TestCase
             'guard_name' => 'web',
             'conference_id' => 0,
             'scheduled_conference_id' => 0,
+        ]);
+    }
+
+    protected function createScheduledConferenceRole(
+        UserRole $role,
+        Conference $conference,
+        ScheduledConference $scheduledConference
+    ): Role {
+        return Role::withoutGlobalScopes()->firstOrCreate([
+            'name' => $role->value,
+            'guard_name' => 'web',
+            'conference_id' => $conference->getKey(),
+            'scheduled_conference_id' => $scheduledConference->getKey(),
         ]);
     }
 }

--- a/tests/Feature/ScheduledConferenceLoginTest.php
+++ b/tests/Feature/ScheduledConferenceLoginTest.php
@@ -27,6 +27,20 @@ class ScheduledConferenceLoginTest extends TestCase
             ->assertSee('Hide password', false);
     }
 
+    public function test_scheduled_conference_login_hides_register_action_when_registration_is_disabled(): void
+    {
+        $scheduledConference = $this->makeScheduledConference();
+        $scheduledConference->setMeta('allow_registration', false);
+
+        $this->withoutVite()
+            ->get(route(Login::getRouteName('scheduledConference'), [
+                'conference' => $scheduledConference->conference->path,
+                'serie' => $scheduledConference->path,
+            ]))
+            ->assertOk()
+            ->assertDontSee(__('general.register'));
+    }
+
     protected function makeScheduledConference(): ScheduledConference
     {
         $conference = Conference::query()->create([

--- a/tests/Feature/ScheduledConferenceRegisterTest.php
+++ b/tests/Feature/ScheduledConferenceRegisterTest.php
@@ -6,6 +6,7 @@ use App\Frontend\ScheduledConference\Pages\Register;
 use App\Models\Conference;
 use App\Models\ScheduledConference;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
 use Tests\TestCase;
 
 class ScheduledConferenceRegisterTest extends TestCase
@@ -28,7 +29,7 @@ class ScheduledConferenceRegisterTest extends TestCase
             ->assertDontSee('link link-primary', false);
     }
 
-    public function test_registration_page_is_forbidden_when_registration_is_disabled(): void
+    public function test_registration_page_shows_closed_message_when_registration_is_disabled(): void
     {
         $scheduledConference = $this->makeScheduledConference();
         $scheduledConference->setMeta('allow_registration', false);
@@ -38,7 +39,24 @@ class ScheduledConferenceRegisterTest extends TestCase
                 'conference' => $scheduledConference->conference->path,
                 'serie' => $scheduledConference->path,
             ]))
-            ->assertForbidden();
+            ->assertOk()
+            ->assertSee(__('general.registration_closed'))
+            ->assertDontSee('wire:submit="register"', false);
+    }
+
+    public function test_registration_submission_is_ignored_when_registration_is_disabled(): void
+    {
+        $scheduledConference = $this->makeScheduledConference();
+        $scheduledConference->setMeta('allow_registration', false);
+
+        Livewire::test(Register::class)
+            ->set('email', 'closed-registration@example.test')
+            ->call('register')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseMissing('users', [
+            'email' => 'closed-registration@example.test',
+        ]);
     }
 
     protected function makeScheduledConference(): ScheduledConference

--- a/tests/Feature/ScheduledConferenceRegisterTest.php
+++ b/tests/Feature/ScheduledConferenceRegisterTest.php
@@ -28,6 +28,19 @@ class ScheduledConferenceRegisterTest extends TestCase
             ->assertDontSee('link link-primary', false);
     }
 
+    public function test_registration_page_is_forbidden_when_registration_is_disabled(): void
+    {
+        $scheduledConference = $this->makeScheduledConference();
+        $scheduledConference->setMeta('allow_registration', false);
+
+        $this->withoutVite()
+            ->get(route(Register::getRouteName('scheduledConference'), [
+                'conference' => $scheduledConference->conference->path,
+                'serie' => $scheduledConference->path,
+            ]))
+            ->assertForbidden();
+    }
+
     protected function makeScheduledConference(): ScheduledConference
     {
         $conference = Conference::query()->create([


### PR DESCRIPTION
## Summary

- Show a friendly `registration_closed` state on the scheduled conference registration page when `allow_registration` is disabled instead of returning a 403 page.
- Ignore stale/direct public Livewire registration submissions while registration is closed, without creating a user.
- Hide the scheduled conference login register action when registration is closed.
- Make participant registration availability require both `allow_registration` and participant payment.
- Guard participant registration submit so stale/direct Livewire submissions cannot create a participant or queued payment after registration closes.
- Add regression coverage for the closed public register page, closed submit guards, login register action, and participant registration access gate.

## Root Cause

The scheduled conference registration setting was previously enforced only on public form submission and navigation visibility. Direct page access could still render the form, the login page still exposed the register action, and participant registration was only gated by `participant_payment`. The first fix used a 403 for direct page access, but that creates a confusing UX for visitors when registration is intentionally closed. Codex review also caught that participant registration needed the same submit-time guard as the public register flow because a stale Livewire component can submit after settings change.

## Validation

- `php82 vendor/bin/pint app/Panel/ScheduledConference/Pages/ParticipantRegistration.php tests/Feature/OperationalNotificationRecipientsTest.php`
- `php82 artisan test tests/Feature/OperationalNotificationRecipientsTest.php --filter=participant_registration`
- `php82 artisan test tests/Feature/ScheduledConferenceRegisterTest.php tests/Feature/ScheduledConferenceLoginTest.php tests/Feature/ScheduledConferenceAccessFlowTest.php`
- `git diff --check`