### PR TITLE
Allow isolated upgrade without auth restriction

### DIFF
--- a/app/Frontend/Website/Pages/Upgrade.php
+++ b/app/Frontend/Website/Pages/Upgrade.php
@@ -7,7 +7,6 @@ use App\Facades\MetaTag;
 use App\Http\Middleware\RedirectToConference;
 use App\Http\Middleware\SetLocale;
 use App\Http\Middleware\SetupDefaultData;
-use App\Models\Enums\UserRole;
 
 class Upgrade extends Page
 {
@@ -22,8 +21,6 @@ class Upgrade extends Page
     public function mount()
     {
         MetaTag::add('robots', 'noindex, nofollow');
-
-        abort_unless(auth()->check() && auth()->user()->hasRole(UserRole::Admin), 403);
 
         if (version_compare(app()->getInstalledVersion(), app()->getCodeVersion(), '>=')) {
             return redirect('/');
@@ -45,8 +42,6 @@ class Upgrade extends Page
 
     public function upgrade()
     {
-        abort_unless(auth()->check() && auth()->user()->hasRole(UserRole::Admin), 403);
-
         try {
             UpgradeAction::run();
 

--- a/tests/Feature/UpgradePageTest.php
+++ b/tests/Feature/UpgradePageTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Actions\Leconfe\UpgradeAction;
+use App\Frontend\Website\Pages\Upgrade;
+use App\Models\Version;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class UpgradePageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_upgrade_page_is_accessible_without_authentication_while_upgrading(): void
+    {
+        $this->prepareUpgradingApplication();
+
+        $this->withoutVite()
+            ->get(route(Upgrade::getRouteName('website')))
+            ->assertOk()
+            ->assertSee('Installed Version')
+            ->assertSee('v0.0.1');
+    }
+
+    public function test_upgrade_action_can_run_without_authentication_while_upgrading(): void
+    {
+        $this->prepareUpgradingApplication();
+
+        UpgradeAction::allowToRun();
+
+        Livewire::test(Upgrade::class)
+            ->call('upgrade')
+            ->assertRedirect(route('livewirePageGroup.website.pages.installation-successful'));
+    }
+
+    protected function prepareUpgradingApplication(): void
+    {
+        Config::set('app.installed', true);
+
+        Version::query()->create([
+            'product_name' => 'Leconfe',
+            'product_folder' => 'leconfe',
+            'version' => '0.0.1',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- Remove the Auth/Admin guard from the website upgrade page and Livewire upgrade action.
- Add feature coverage that the isolated upgrade flow can be opened and triggered without authentication while the app is upgrading.

## Why
The upgrade flow is already isolated by the application upgrade state, so the page should not require an authenticated admin session.

## Validation
- `php artisan test --filter=Upgrade`
- `./vendor/bin/pint --test app/Frontend/Website/Pages/Upgrade.php tests/Feature/UpgradePageTest.php`