### PR TITLE
Fix version header newline

### DIFF
--- a/app/Application.php
+++ b/app/Application.php
@@ -67,7 +67,7 @@ class Application extends LaravelApplication
 
     public function getCodeVersion(): string
     {
-        return File::get(base_path('version'));
+        return trim(File::get(base_path('version')));
     }
 
     public function getVersion()
@@ -300,7 +300,7 @@ class Application extends LaravelApplication
 
     public function getApiUrl(?string $path = null): string
     {
-        return config('app.api_url') . $path;
+        return config('app.api_url').$path;
     }
 
     public function isOnScheduledConference(): bool
@@ -310,15 +310,18 @@ class Application extends LaravelApplication
 
     public function isOnConference(): bool
     {
-        if ($this->isOnScheduledConference()) return false;
-
+        if ($this->isOnScheduledConference()) {
+            return false;
+        }
 
         return (bool) $this->getCurrentConferenceId();
     }
 
     public function isOnSite(): bool
     {
-        if ($this->isOnConference() || $this->isOnScheduledConference()) return false;
+        if ($this->isOnConference() || $this->isOnScheduledConference()) {
+            return false;
+        }
 
         return true;
     }

--- a/tests/Unit/ApplicationVersionTest.php
+++ b/tests/Unit/ApplicationVersionTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+class ApplicationVersionTest extends TestCase
+{
+    public function test_code_version_trims_version_file_contents(): void
+    {
+        File::shouldReceive('get')
+            ->once()
+            ->with(base_path('version'))
+            ->andReturn("1.5.0-beta.1\n");
+
+        $this->assertSame('1.5.0-beta.1', app()->getCodeVersion());
+    }
+}


### PR DESCRIPTION
## Summary
- Trim the `version` file value before exposing it through `app()->getCodeVersion()`.
- Add a regression test for version files that include a trailing newline.
- Apply Pint cleanup in `app/Application.php` for touched-file style compliance.

## Root Cause
The `version` file contains a trailing newline, and `getCodeVersion()` returned the raw file contents. That value was used in global HTTP headers (`Leconfe-Version` and `User-Agent`), causing Guzzle to reject requests with an invalid header value.

## Verification
- `php82 artisan test --testsuite=Unit`
- `php82 vendor/bin/pint --test app/Application.php tests/Unit/ApplicationVersionTest.php`
- `php82 artisan tinker --execute "new GuzzleHttp\\Psr7\\Request('GET', 'https://example.com', ['Leconfe-Version' => app()->getCodeVersion(), 'User-Agent' => 'Leconfe/'.app()->getCodeVersion()]); echo app()->getCodeVersion();"`