### PR TITLE
Allow users to edit their own account from User resources

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -288,7 +288,19 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, HasMedia,
     public function syncRoles(...$roles)
     {
         if ($this->getModel()->exists) {
-            $this->roles()->detach($this->roles->filter(fn ($role) => $role->name != UserRole::Admin->value)->pluck('id')->toArray());
+            $rolesToDetach = $this->roles->filter(fn ($role) => $role->name != UserRole::Admin->value);
+
+            if (app()->getCurrentConferenceId() || app()->getCurrentScheduledConferenceId()) {
+                $contextRoleIds = Role::withoutGlobalScopes()
+                    ->availableRolesByContext()
+                    ->where('name', '!=', UserRole::Admin->value)
+                    ->pluck('id')
+                    ->all();
+
+                $rolesToDetach = $rolesToDetach->whereIn('id', $contextRoleIds);
+            }
+
+            $this->roles()->detach($rolesToDetach->pluck('id')->toArray());
             $this->setRelation('roles', collect());
         }
 

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -50,7 +50,7 @@ class UserPolicy
     public function update(User $user, User $model)
     {
         if ($user->is($model)) {
-            return false;
+            return true;
         }
 
         if ($model->hasRole(UserRole::Admin)) {

--- a/tests/Feature/ScheduledConferenceAccessFlowTest.php
+++ b/tests/Feature/ScheduledConferenceAccessFlowTest.php
@@ -20,7 +20,7 @@ class ScheduledConferenceAccessFlowTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_current_admin_is_visible_in_conference_user_search_without_reopening_self_edit(): void
+    public function test_current_admin_is_visible_in_conference_user_search_and_can_self_edit(): void
     {
         $conference = Conference::query()->create([
             'name' => 'Test Conference',
@@ -48,7 +48,7 @@ class ScheduledConferenceAccessFlowTest extends TestCase
 
         $this->assertTrue($visibleUserIds->contains($admin->getKey()));
         $this->assertFalse($visibleUserIds->contains($otherAdmin->getKey()));
-        $this->assertFalse(app(UserPolicy::class)->update($admin, $admin));
+        $this->assertTrue(app(UserPolicy::class)->update($admin, $admin));
         $this->assertFalse(app(UserPolicy::class)->delete($admin, $admin));
     }
 

--- a/tests/Feature/UserRoleScopeTest.php
+++ b/tests/Feature/UserRoleScopeTest.php
@@ -61,6 +61,73 @@ class UserRoleScopeTest extends TestCase
         ]);
     }
 
+    public function test_scheduled_context_role_sync_preserves_conference_scoped_roles(): void
+    {
+        $conference = Conference::query()->create([
+            'name' => 'Scoped Conference',
+            'path' => 'scoped-conference',
+        ]);
+        $scheduledConference = ScheduledConference::query()->create([
+            'conference_id' => $conference->getKey(),
+            'title' => 'Scoped Schedule',
+            'path' => 'scoped-schedule',
+        ]);
+
+        $conferenceManagerRole = Role::withoutGlobalScopes()->firstOrCreate([
+            'name' => UserRole::ConferenceManager->value,
+            'guard_name' => 'web',
+            'conference_id' => $conference->getKey(),
+            'scheduled_conference_id' => 0,
+        ]);
+        $scheduledEditorRole = Role::withoutGlobalScopes()->firstOrCreate([
+            'name' => UserRole::ScheduledConferenceEditor->value,
+            'guard_name' => 'web',
+            'conference_id' => $conference->getKey(),
+            'scheduled_conference_id' => $scheduledConference->getKey(),
+        ]);
+        $trackEditorRole = Role::withoutGlobalScopes()->firstOrCreate([
+            'name' => UserRole::TrackEditor->value,
+            'guard_name' => 'web',
+            'conference_id' => $conference->getKey(),
+            'scheduled_conference_id' => $scheduledConference->getKey(),
+        ]);
+
+        $user = User::factory()->create([
+            'email' => 'scoped-sync@example.test',
+            'password' => Hash::make('password12345'),
+        ]);
+
+        app()->setCurrentConferenceId($conference->getKey());
+        app()->setCurrentScheduledConferenceId($scheduledConference->getKey());
+
+        $user->assignRole($conferenceManagerRole);
+        $user->assignRole($scheduledEditorRole);
+
+        $user->syncRoles([$trackEditorRole->name]);
+
+        $this->assertDatabaseHas('model_has_roles', [
+            'role_id' => $conferenceManagerRole->getKey(),
+            'conference_id' => $conference->getKey(),
+            'scheduled_conference_id' => 0,
+            'model_type' => User::class,
+            'model_id' => $user->getKey(),
+        ]);
+        $this->assertDatabaseMissing('model_has_roles', [
+            'role_id' => $scheduledEditorRole->getKey(),
+            'conference_id' => $conference->getKey(),
+            'scheduled_conference_id' => $scheduledConference->getKey(),
+            'model_type' => User::class,
+            'model_id' => $user->getKey(),
+        ]);
+        $this->assertDatabaseHas('model_has_roles', [
+            'role_id' => $trackEditorRole->getKey(),
+            'conference_id' => $conference->getKey(),
+            'scheduled_conference_id' => $scheduledConference->getKey(),
+            'model_type' => User::class,
+            'model_id' => $user->getKey(),
+        ]);
+    }
+
     public function test_role_scope_does_not_leak_from_other_conferences(): void
     {
         app()->setCurrentConferenceId(103);

--- a/tests/Feature/UserRoleScopeTest.php
+++ b/tests/Feature/UserRoleScopeTest.php
@@ -255,7 +255,7 @@ class UserRoleScopeTest extends TestCase
 
         $this->assertTrue($listedUserIds->contains($admin->getKey()));
         $this->assertFalse($listedUserIds->contains($foreignUser->getKey()));
-        $this->assertFalse(Gate::forUser($admin)->allows('update', $admin));
+        $this->assertTrue(Gate::forUser($admin)->allows('update', $admin));
         $this->assertFalse(Gate::forUser($admin)->allows('delete', $admin));
     }
 


### PR DESCRIPTION
## Summary
- Allow users to update their own user resource record, including admin users.
- Keep protections for editing other admin users and deleting self intact.
- Update regression coverage for conference and scheduled-conference user resource visibility.

## Tests
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test tests/Feature/ScheduledConferenceAccessFlowTest.php tests/Feature/UserRoleScopeTest.php
- ./vendor/bin/pint --dirty --test
- php -l app/Policies/UserPolicy.php && php -l tests/Feature/ScheduledConferenceAccessFlowTest.php && php -l tests/Feature/UserRoleScopeTest.php
- git diff --check