### PR TITLE
Fix receipt notes footer

### DIFF
--- a/resources/views/panel/scheduledConference/pages/receipt.blade.php
+++ b/resources/views/panel/scheduledConference/pages/receipt.blade.php
@@ -94,15 +94,12 @@
             @endif
             <p>Thank you for your payment. We look forward to your participation and wish you a successful and enjoyable conference experience.</p>
         </div>
-        @if($scheduledConference->getMeta('receipt_notes'))
+        @php($receiptNotes = $scheduledConference->getMeta('receipt_notes'))
+        @if($receiptNotes)
         <div class="mt-4 max-w-none prose prose-sm prose-p:my-0 prose-p:leading-5 prose-li:leading-5 prose-ol:mt-0" style="--tw-prose-body: #000;--tw-prose-counters: #000;">
-            {!! $scheduledConference->getMeta('receipt_notes') !!}
+            {!! $receiptNotes !!}
         </div>
         @endif
-        <div class="mt-8 font-bold">
-            <p>With best regards,</p>
-            <p>{{ $scheduledConference->getMeta('organizer') }}</p>
-        </div>
     </div>
 </body>
 

--- a/tests/Feature/SubmissionBillingNotifierTest.php
+++ b/tests/Feature/SubmissionBillingNotifierTest.php
@@ -332,10 +332,12 @@ class SubmissionBillingNotifierTest extends TestCase
         );
 
         $context['scheduledConference']->update(['is_published' => true]);
-        $context['scheduledConference']->setManyMeta([
+        $receiptMeta = [
             'receipt_enable' => true,
             'receipt_notes' => '<p>Bring this receipt to check-in.</p>',
-        ]);
+        ];
+        $context['scheduledConference']->setManyMeta($receiptMeta);
+        app()->getCurrentScheduledConference()?->setManyMeta($receiptMeta);
 
         $this->queueSubmissionPayment($context['submission'], $context['paymentFee']);
 
@@ -347,10 +349,21 @@ class SubmissionBillingNotifierTest extends TestCase
 
         $this->actingAs($context['user']);
 
-        $this->withoutVite()
+        $response = $this->withoutVite()
             ->get($this->getReceiptUrl($context, $payment))
             ->assertOk()
             ->assertSee('Bring this receipt to check-in.');
+
+        $visibleText = trim(preg_replace('/\s+/', ' ', html_entity_decode(strip_tags($response->getContent()))));
+        $thankYou = 'Thank you for your payment. We look forward to your participation and wish you a successful and enjoyable conference experience.';
+
+        $this->assertStringContainsString($thankYou, $visibleText);
+        $this->assertLessThan(
+            strpos($visibleText, 'Bring this receipt to check-in.'),
+            strpos($visibleText, $thankYou),
+        );
+        $this->assertStringNotContainsString('With best regards', $visibleText);
+        $this->assertStringEndsWith('Bring this receipt to check-in.', $visibleText);
     }
 
     public function test_submission_receipt_does_not_show_submission_title_by_default(): void


### PR DESCRIPTION
## Summary
- Keep the receipt thank-you paragraph before receipt notes.
- Render receipt notes as the final receipt content with no organizer closing text afterward.
- Extend the receipt notes regression test to verify ordering and final text.

## Tests
- rtk php artisan test tests/Feature/SubmissionBillingNotifierTest.php
- rtk php artisan test tests/Feature/SubmissionBillingNotifierTest.php --filter=receipt_page_shows_receipt_notes
- rtk ./vendor/bin/pint --test tests/Feature/SubmissionBillingNotifierTest.php
- rtk php -l tests/Feature/SubmissionBillingNotifierTest.php && rtk php -l app/Panel/ScheduledConference/Pages/Receipt.php
- rtk git diff --check -- resources/views/panel/scheduledConference/pages/receipt.blade.php tests/Feature/SubmissionBillingNotifierTest.php