### PR TITLE
Fix review submission keywords

### DIFF
--- a/app/Panel/ScheduledConference/Resources/SubmissionResource/Pages/ReviewSubmissionPage.php
+++ b/app/Panel/ScheduledConference/Resources/SubmissionResource/Pages/ReviewSubmissionPage.php
@@ -115,9 +115,8 @@ class ReviewSubmissionPage extends Page implements HasActions, HasInfolists
                                 TextEntry::make('keywords')
                                     ->label(__('general.keywords'))
                                     ->color('gray')
-                                    ->getStateUsing(
-                                        fn (Submission $record): string => $record->tagsWithType('submissionKeywords')->pluck('name')->join(', ') ?: '-'
-                                    ),
+                                    ->badge()
+                                    ->getStateUsing(fn (Submission $record) => $record->getMeta('keywords') ?: '-'),
                                 TextEntry::make('abstract')
                                     ->label(__('general.abstract'))
                                     ->color('gray')

--- a/tests/Feature/SubmissionReviewRoundWorkflowTest.php
+++ b/tests/Feature/SubmissionReviewRoundWorkflowTest.php
@@ -1937,6 +1937,58 @@ class SubmissionReviewRoundWorkflowTest extends TestCase
         $this->assertNull($review->recommendation);
     }
 
+    public function test_review_submission_page_shows_submission_keywords_from_author_metadata(): void
+    {
+        $context = $this->makeSubmissionContext();
+        $reviewerRole = $this->createReviewerRole();
+
+        foreach (['Submission:review', 'Submission:viewAny'] as $permissionName) {
+            Permission::query()->firstOrCreate([
+                'name' => $permissionName,
+                'guard_name' => 'web',
+            ]);
+        }
+
+        $reviewerRole->syncPermissions(['Submission:review', 'Submission:viewAny']);
+        $context['reviewerA']->assignRole($reviewerRole);
+
+        $context['submission']->scheduledConference->update(['is_published' => true]);
+        $context['submission']->setManyMeta([
+            'abstract' => '<p>Reviewable submission abstract.</p>',
+            'keywords' => [
+                'deep learning',
+                'decision support',
+            ],
+        ]);
+
+        $round = StartSubmissionReviewRoundAction::run(
+            $context['submission'],
+            [],
+            $context['editor'],
+        );
+
+        $review = Review::query()->create([
+            'submission_id' => $context['submission']->getKey(),
+            'review_round_id' => $round->getKey(),
+            'user_id' => $context['reviewerA']->getKey(),
+            'status' => ReviewerStatus::ACCEPTED,
+            'date_confirmed' => now(),
+        ]);
+        $review->setMeta('review_mode', Review::MODE_OPEN);
+        $review->save();
+
+        $this->actingAs($context['reviewerA']);
+
+        $this->get(route('filament.scheduledConference.resources.submissions.review', [
+            'conference' => $context['submission']->conference->path,
+            'serie' => $context['submission']->scheduledConference->path,
+            'record' => $context['submission']->getKey(),
+        ]))
+            ->assertOk()
+            ->assertSee('deep learning')
+            ->assertSee('decision support');
+    }
+
     public function test_stale_reviewer_invitation_page_rejects_accept_after_a_new_round_starts(): void
     {
         $context = $this->makeSubmissionContext();


### PR DESCRIPTION
## Summary
- Display review detail keywords from submission metadata instead of the unused submission keyword tag lookup.
- Add a regression test that opens the reviewer detail page and asserts author-entered keywords are visible.

## Root Cause
The review detail page read keywords from `tagsWithType('submissionKeywords')`, while the author submission flow stores them in submission meta as `keywords`.

## Verification
- `php artisan test tests/Feature/SubmissionReviewRoundWorkflowTest.php`
- `./vendor/bin/pint --test app/Panel/ScheduledConference/Resources/SubmissionResource/Pages/ReviewSubmissionPage.php tests/Feature/SubmissionReviewRoundWorkflowTest.php`
- `git diff --check`