### PR TITLE
fix: show scheduled conference title in invitation email

### DIFF
--- a/app/Mail/Templates/UserRoleInvitationMail.php
+++ b/app/Mail/Templates/UserRoleInvitationMail.php
@@ -15,7 +15,8 @@ class UserRoleInvitationMail extends TemplateMailable
 
     public function __construct(UserInvitation $invitation)
     {
-        $conferenceTitle = $invitation->scheduledConference?->conference?->name
+        $conferenceTitle = $invitation->scheduledConference?->title
+            ?? $invitation->scheduledConference?->conference?->name
             ?? $invitation->conference?->name
             ?? app()->getCurrentConference()?->name
             ?? app()->getSite()->getMeta('name');


### PR DESCRIPTION
## Problem

When inviting a user from a scheduled conference dashboard, the invitation email shows the **parent conference name** instead of the **scheduled conference title**. For example, an invitation to "3RD BIENNIAL CONFERENCE OF NAL" would show the parent conference name in the email body.

## Root Cause

`UserRoleInvitationMail` resolved `$conferenceTitle` starting from the parent conference:

```php
$conferenceTitle = $invitation->scheduledConference?->conference?->name  // parent
    ?? $invitation->conference?->name
    ?? ...
```

## Fix

Re-prioritize the resolution chain to use the scheduled conference title first:

```php
$conferenceTitle = $invitation->scheduledConference?->title          // "3RD BIENNIAL CONFERENCE"
    ?? $invitation->scheduledConference?->conference?->name           // parent fallback
    ?? $invitation->conference?->name                                 // no scheduled conference
    ?? app()->getCurrentConference()?->name
    ?? app()->getSite()->getMeta('name');
```

## Changes

| File | Change |
|---|---|
| `app/Mail/Templates/UserRoleInvitationMail.php` | +2/-1 — `$conferenceTitle` prefers `scheduledConference->title` |