### PR TITLE
fix: show scheduled conference title in invitation email

### DIFF
--- a/app/Mail/Templates/UserRoleInvitationMail.php
+++ b/app/Mail/Templates/UserRoleInvitationMail.php
@@ -15,7 +15,8 @@ class UserRoleInvitationMail extends TemplateMailable
 
     public function __construct(UserInvitation $invitation)
     {
-        $conferenceTitle = $invitation->scheduledConference?->conference?->name
+        $conferenceTitle = $invitation->scheduledConference?->title
+            ?? $invitation->scheduledConference?->conference?->name
             ?? $invitation->conference?->name
             ?? app()->getCurrentConference()?->name
             ?? app()->getSite()->getMeta('name');


### PR DESCRIPTION
Cherry-pick of #814 from 1.4.x.

## Problem

When inviting a user from a scheduled conference dashboard, the invitation email shows the parent conference name instead of the scheduled conference title.

## Root Cause

`UserRoleInvitationMail` resolved `$conferenceTitle` starting from the parent conference name instead of the scheduled conference title.

## Fix

Re-prioritize resolution: `scheduledConference->title` → `scheduledConference->conference->name` → `conference->name` → app context → site name.

## Changes

| File | Change |
|---|---|
| `app/Mail/Templates/UserRoleInvitationMail.php` | +2/-1 |