### PR TITLE
Fix scheduled conference email context

### DIFF
--- a/app/Mail/Templates/TemplateMailable.php
+++ b/app/Mail/Templates/TemplateMailable.php
@@ -41,6 +41,20 @@ abstract class TemplateMailable extends BaseTemplateMailable implements Interfac
 
     public static function getConferenceViewData()
     {
+        $scheduledConference = app()->getCurrentScheduledConference();
+
+        if ($scheduledConference) {
+            $logo = $scheduledConference->getFirstMedia('logo')
+                ?? $scheduledConference->conference?->getFirstMedia('logo');
+
+            return [
+                'conferenceName' => $scheduledConference->title,
+                'conferenceLink' => $scheduledConference->getHomeUrl(),
+                'conferenceLogoUrl' => $logo?->getAvailableUrl(['thumb', 'thumb-xl']),
+                'conferenceLogoAltText' => $scheduledConference->title,
+            ];
+        }
+
         $conference = app()->getCurrentConference();
 
         if (! $conference) {
@@ -58,7 +72,12 @@ abstract class TemplateMailable extends BaseTemplateMailable implements Interfac
     public function envelope(): Envelope
     {
         return new Envelope(
-            from: new Address(config('mail.from.address'), app()->getCurrentConference()->name ?? app()->getSite()->getMeta('name')),
+            from: new Address(
+                config('mail.from.address'),
+                app()->getCurrentScheduledConference()?->title
+                    ?? app()->getCurrentConference()?->name
+                    ?? app()->getSite()->getMeta('name')
+            ),
         );
     }
 

--- a/tests/Feature/ScheduledConferenceMailTemplateTest.php
+++ b/tests/Feature/ScheduledConferenceMailTemplateTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Mail\Templates\TemplateMailable;
+use App\Mail\Templates\TestMail;
+use App\Models\Conference;
+use App\Models\MailTemplate;
+use App\Models\ScheduledConference;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use ReflectionClass;
+use Tests\TestCase;
+
+class ScheduledConferenceMailTemplateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_subject_keeps_using_conference_name_without_scheduled_conference_context(): void
+    {
+        $conference = Conference::query()->create([
+            'name' => 'Parent Conference',
+            'path' => 'parent-conference',
+        ]);
+
+        app()->setCurrentConferenceId($conference->getKey());
+        app()->setCurrentScheduledConferenceId(0);
+
+        MailTemplate::query()->create([
+            'conference_id' => $conference->getKey(),
+            'mailable' => TestMail::class,
+            'subject' => 'Mail from {{ conferenceName }}',
+            'html_template' => 'Body',
+            'text_template' => 'Body',
+        ]);
+
+        $mail = new TestMail;
+
+        $this->assertSame('Parent Conference', $mail->buildViewData()['conferenceName']);
+        $this->assertSame('Mail from Parent Conference', $this->renderSubject($mail));
+    }
+
+    public function test_subject_uses_scheduled_conference_name_in_scheduled_conference_context(): void
+    {
+        $conference = Conference::query()->create([
+            'name' => 'Parent Conference',
+            'path' => 'parent-conference',
+        ]);
+
+        $scheduledConference = ScheduledConference::withoutGlobalScopes()->create([
+            'conference_id' => $conference->getKey(),
+            'title' => 'Scheduled Conference 2026',
+            'path' => 'scheduled-2026',
+            'date_start' => now()->toDateString(),
+            'date_end' => now()->addDay()->toDateString(),
+        ]);
+
+        app()->setCurrentConferenceId($conference->getKey());
+        app()->setCurrentScheduledConferenceId($scheduledConference->getKey());
+
+        MailTemplate::query()->create([
+            'conference_id' => $conference->getKey(),
+            'mailable' => TestMail::class,
+            'subject' => 'Mail from {{ conferenceName }}',
+            'html_template' => 'Body',
+            'text_template' => 'Body',
+        ]);
+
+        $this->assertSame(
+            'Mail from Scheduled Conference 2026',
+            $this->renderSubject(new TestMail)
+        );
+    }
+
+    private function renderSubject(TemplateMailable $mail): string
+    {
+        $message = new class
+        {
+            public string $subject = '';
+
+            public function subject(string $subject): self
+            {
+                $this->subject = $subject;
+
+                return $this;
+            }
+        };
+
+        $method = (new ReflectionClass(TemplateMailable::class))->getMethod('buildSubject');
+        $method->setAccessible(true);
+        $method->invoke($mail, $message);
+
+        return $message->subject;
+    }
+}


### PR DESCRIPTION
## Summary
- Cherry-pick the scheduled conference email context fix onto 1.5.x.
- Use the scheduled conference as the mail context when rendering template variables and sender names.
- Keep the existing conference fallback for non-scheduled conference emails.
- Add regression coverage for both scheduled and non-scheduled email subjects.

Cherry-picked from `cf640b6a` / PR #817.

## Validation
- php artisan test tests/Feature/ScheduledConferenceMailTemplateTest.php tests/Feature/WebsiteResetPasswordTest.php tests/Feature/InvitationRegisterTest.php
- ./vendor/bin/pint --test app/Mail/Templates/TemplateMailable.php tests/Feature/ScheduledConferenceMailTemplateTest.php
- php -l app/Mail/Templates/TemplateMailable.php
- php -l tests/Feature/ScheduledConferenceMailTemplateTest.php
- git diff --check