### PR TITLE
Add self author shortcut

### DIFF
--- a/app/Panel/ScheduledConference/Livewire/Submissions/Components/ContributorList.php
+++ b/app/Panel/ScheduledConference/Livewire/Submissions/Components/ContributorList.php
@@ -134,6 +134,7 @@ class ContributorList extends \Livewire\Component implements HasForms, HasTable
                 Action::make('addMyselfAsContributor')
                     ->label(__('general.add_myself_as_contributor'))
                     ->icon('heroicon-o-user')
+                    ->requiresConfirmation()
                     ->action(fn () => $this->addMyselfAsContributor())
                     ->hidden(fn (): bool => ! $this->canAddMyselfAsContributor()),
                 CreateAction::make()

--- a/app/Panel/ScheduledConference/Livewire/Submissions/Components/ContributorList.php
+++ b/app/Panel/ScheduledConference/Livewire/Submissions/Components/ContributorList.php
@@ -7,6 +7,8 @@ use App\Actions\Authors\AuthorDeleteAction;
 use App\Actions\Authors\AuthorUpdateAction;
 use App\Forms\Components\SpatieMediaLibraryFileUpload;
 use App\Models\Author;
+use App\Models\AuthorRole;
+use App\Models\Enums\SubmissionStage;
 use App\Models\Submission;
 use App\Panel\Conference\Livewire\Forms\Conferences\ContributorForm;
 use Filament\Forms\Components\Checkbox;
@@ -16,6 +18,8 @@ use Filament\Forms\Components\TextInput;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Forms\Form;
+use Filament\Notifications\Notification;
+use Filament\Tables\Actions\Action;
 use Filament\Tables\Actions\ActionGroup;
 use Filament\Tables\Actions\CreateAction;
 use Filament\Tables\Actions\DeleteAction;
@@ -27,6 +31,7 @@ use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\UniqueConstraintViolationException;
 
 class ContributorList extends \Livewire\Component implements HasForms, HasTable
 {
@@ -126,6 +131,11 @@ class ContributorList extends \Livewire\Component implements HasForms, HasTable
                     ->hidden($this->viewOnly),
             ])
             ->headerActions([
+                Action::make('addMyselfAsContributor')
+                    ->label(__('general.add_myself_as_contributor'))
+                    ->icon('heroicon-o-user')
+                    ->action(fn () => $this->addMyselfAsContributor())
+                    ->hidden(fn (): bool => ! $this->canAddMyselfAsContributor()),
                 CreateAction::make()
                     ->label(__('general.new_contributor'))
                     ->modalWidth('2xl')
@@ -163,6 +173,84 @@ class ContributorList extends \Livewire\Component implements HasForms, HasTable
                     ->color('success'),
 
             ]);
+    }
+
+    public function addMyselfAsContributor(): void
+    {
+        if (! $this->canAddMyselfAsContributor()) {
+            return;
+        }
+
+        $user = auth()->user();
+        $authorRole = $this->getDefaultAuthorRole();
+
+        if (! $user || ! $authorRole) {
+            return;
+        }
+
+        $meta = collect([
+            'public_name' => $user->getMeta('public_name'),
+            'affiliation' => $user->getMeta('affiliation'),
+            'country' => $user->getMeta('country'),
+            'phone' => $user->getMeta('phone'),
+        ])
+            ->filter(fn ($value): bool => filled($value))
+            ->all();
+
+        try {
+            $author = AuthorCreateAction::run($this->submission, [
+                'author_role_id' => $authorRole->getKey(),
+                'given_name' => $user->given_name,
+                'family_name' => $user->family_name,
+                'email' => $user->email,
+                'meta' => $meta,
+            ]);
+        } catch (UniqueConstraintViolationException) {
+            return;
+        }
+
+        if ($this->submission->authors()->count() === 1) {
+            $this->submission->setPrimaryContact($author);
+        }
+
+        Notification::make()
+            ->title(__('general.contributor_added'))
+            ->success()
+            ->send();
+    }
+
+    public function canAddMyselfAsContributor(): bool
+    {
+        $user = auth()->user();
+
+        if ($this->viewOnly || ! $user) {
+            return false;
+        }
+
+        if ($this->submission->user_id !== $user->getKey()) {
+            return false;
+        }
+
+        if (! in_array($this->submission->stage, [null, SubmissionStage::Wizard], true)) {
+            return false;
+        }
+
+        if (! $this->getDefaultAuthorRole()) {
+            return false;
+        }
+
+        return ! $this->submission
+            ->authors()
+            ->where('email', $user->email)
+            ->exists();
+    }
+
+    protected function getDefaultAuthorRole(): ?AuthorRole
+    {
+        return AuthorRole::withoutGlobalScopes()
+            ->where('conference_id', $this->submission->conference_id)
+            ->where('name', 'Author')
+            ->first();
     }
 
     public function render()

--- a/lang/ar/general.php
+++ b/lang/ar/general.php
@@ -406,6 +406,7 @@ return [
 
     'create_author_role' => 'إنشاء دور مؤلف',
     'new_contributor' => 'مساهم جديد',
+    'add_myself_as_contributor' => 'إضافة نفسي',
     'add_contributor' => 'إضافة مساهم',
     'contributor_added' => 'تمت إضافة المساهم',
     'abstract_files' => 'ملفات الملخص',

--- a/lang/en/general.php
+++ b/lang/en/general.php
@@ -425,6 +425,7 @@ return [
 
     'create_author_role' => 'Create Author Role',
     'new_contributor' => 'New Contributor',
+    'add_myself_as_contributor' => 'Add Myself',
     'add_contributor' => 'Add Contributor',
     'contributor_added' => 'Contributor added',
     'abstract_files' => 'Abstract Files',

--- a/lang/id/general.php
+++ b/lang/id/general.php
@@ -407,6 +407,7 @@ return [
     'file_type_created_successfully' => 'Jenis berkas berhasil dibuat',
     'create_author_role' => 'Buat Peran Penulis',
     'new_contributor' => 'Kontributor Baru',
+    'add_myself_as_contributor' => 'Tambahkan Saya',
     'add_contributor' => 'Tambahkan Kontributor',
     'contributor_added' => 'Kontributor berhasil ditambahkan',
     'abstract_files' => 'Berkas Abstrak',

--- a/lang/ru/general.php
+++ b/lang/ru/general.php
@@ -384,6 +384,7 @@ return [
 
     'create_author_role' => 'Создать роль автора',
     'new_contributor' => 'Новый участник',
+    'add_myself_as_contributor' => 'Добавить себя',
     'add_contributor' => 'Добавить участника',
     'contributor_added' => 'Участник добавлен',
     'abstract_files' => 'Файлы аннотаций',

--- a/lang/sq/general.php
+++ b/lang/sq/general.php
@@ -393,6 +393,7 @@ return [
 
     'create_author_role' => 'Krijo Rol Autor',
     'new_contributor' => 'Kontribues i Ri',
+    'add_myself_as_contributor' => 'Shto veten',
     'add_contributor' => 'Shto Kontribues',
     'contributor_added' => 'Kontribuesi u shtua',
     'abstract_files' => 'Skedarët e Abstraktit',

--- a/lang/uz/general.php
+++ b/lang/uz/general.php
@@ -384,6 +384,7 @@ return [
 
     'create_author_role' => 'Muallif roli yarating',
     'new_contributor' => 'Yangi hissa qo‘shuvchi',
+    'add_myself_as_contributor' => 'O‘zimni qo‘shish',
     'add_contributor' => 'Hissa qo‘shuvchini qo‘shish',
     'contributor_added' => 'Hissa qo‘shuvchi qo‘shildi',
     'abstract_files' => 'Annotatsiya fayllari',

--- a/tests/Feature/ContributorListTest.php
+++ b/tests/Feature/ContributorListTest.php
@@ -2,7 +2,11 @@
 
 namespace Tests\Feature;
 
+use App\Models\Author;
+use App\Models\AuthorRole;
 use App\Models\Conference;
+use App\Models\Enums\SubmissionStage;
+use App\Models\Enums\SubmissionStatus;
 use App\Models\ScheduledConference;
 use App\Models\Submission;
 use App\Models\Track;
@@ -63,17 +67,137 @@ class ContributorListTest extends TestCase
             ->assertFormFieldExists('email', 'mountedTableActionForm');
     }
 
-    protected function makeSubmissionContext(): array
+    public function test_wizard_owner_can_add_themselves_as_contributor(): void
+    {
+        $context = $this->makeSubmissionContext();
+        $context['user']->setManyMeta([
+            'public_name' => 'Published Author',
+            'affiliation' => 'Conference University',
+            'country' => 'id',
+            'phone' => '+628123456789',
+        ]);
+        $authorRole = $this->createAuthorRole($context['conference']);
+
+        $this->actingAs($context['user']);
+
+        Livewire::test(ContributorList::class, ['submission' => $context['submission']])
+            ->assertTableActionVisible('addMyselfAsContributor')
+            ->callTableAction('addMyselfAsContributor')
+            ->assertHasNoTableActionErrors();
+
+        $author = Author::query()
+            ->where('submission_id', $context['submission']->getKey())
+            ->where('email', $context['user']->email)
+            ->firstOrFail();
+
+        $this->assertSame($authorRole->getKey(), $author->author_role_id);
+        $this->assertSame('Author', $author->given_name);
+        $this->assertSame('Tester', $author->family_name);
+        $this->assertSame('Published Author', $author->getMeta('public_name'));
+        $this->assertSame('Conference University', $author->getMeta('affiliation'));
+        $this->assertSame('id', $author->getMeta('country'));
+        $this->assertSame('+628123456789', $author->getMeta('phone'));
+        $this->assertSame($author->getKey(), $context['submission']->fresh()->getMeta('primary_contact_id'));
+    }
+
+    public function test_add_myself_as_contributor_is_idempotent(): void
+    {
+        $context = $this->makeSubmissionContext();
+        $this->createAuthorRole($context['conference']);
+
+        $this->actingAs($context['user']);
+
+        $component = Livewire::test(ContributorList::class, ['submission' => $context['submission']]);
+
+        $component
+            ->callTableAction('addMyselfAsContributor')
+            ->assertHasNoTableActionErrors();
+
+        $component->instance()->addMyselfAsContributor();
+
+        $this->assertSame(
+            1,
+            Author::query()
+                ->where('submission_id', $context['submission']->getKey())
+                ->where('email', $context['user']->email)
+                ->count()
+        );
+    }
+
+    public function test_add_myself_as_contributor_action_hides_in_view_only_mode(): void
+    {
+        $context = $this->makeSubmissionContext();
+        $this->createAuthorRole($context['conference']);
+
+        $this->actingAs($context['user']);
+
+        Livewire::test(ContributorList::class, [
+            'submission' => $context['submission'],
+            'viewOnly' => true,
+        ])
+            ->assertTableActionHidden('addMyselfAsContributor');
+    }
+
+    public function test_add_myself_as_contributor_action_hides_for_non_owner(): void
+    {
+        $context = $this->makeSubmissionContext();
+        $this->createAuthorRole($context['conference']);
+
+        $otherUser = User::query()->create([
+            'given_name' => 'Other',
+            'family_name' => 'Author',
+            'email' => 'other-author@example.test',
+            'password' => 'password123456',
+        ]);
+
+        $this->actingAs($otherUser);
+
+        Livewire::test(ContributorList::class, ['submission' => $context['submission']])
+            ->assertTableActionHidden('addMyselfAsContributor');
+    }
+
+    public function test_add_myself_as_contributor_action_hides_when_author_already_exists(): void
+    {
+        $context = $this->makeSubmissionContext();
+        $authorRole = $this->createAuthorRole($context['conference']);
+
+        $this->actingAs($context['user']);
+
+        $context['submission']->authors()->create([
+            'author_role_id' => $authorRole->getKey(),
+            'given_name' => $context['user']->given_name,
+            'family_name' => $context['user']->family_name,
+            'email' => $context['user']->email,
+        ]);
+
+        Livewire::test(ContributorList::class, ['submission' => $context['submission']])
+            ->assertTableActionHidden('addMyselfAsContributor');
+    }
+
+    public function test_add_myself_as_contributor_action_hides_after_wizard_stage(): void
+    {
+        $submittedContext = $this->makeSubmissionContext([
+            'stage' => SubmissionStage::PeerReview,
+            'status' => SubmissionStatus::OnReview,
+        ]);
+        $this->createAuthorRole($submittedContext['conference']);
+        $this->actingAs($submittedContext['user']);
+
+        Livewire::test(ContributorList::class, ['submission' => $submittedContext['submission']])
+            ->assertTableActionHidden('addMyselfAsContributor');
+    }
+
+    protected function makeSubmissionContext(array $submissionOverrides = []): array
     {
         $conference = Conference::query()->create([
-            'name' => 'Conference',
-            'path' => 'conference',
+            'name' => 'Conference '.uniqid(),
+            'path' => 'conference-'.uniqid(),
         ]);
 
         $scheduledConference = ScheduledConference::withoutGlobalScopes()->create([
             'conference_id' => $conference->getKey(),
-            'title' => 'Scheduled Conference',
-            'path' => 'scheduled-conference',
+            'title' => 'Scheduled Conference '.uniqid(),
+            'path' => 'scheduled-conference-'.uniqid(),
             'date_start' => now()->toDateString(),
             'date_end' => now()->addDays(2)->toDateString(),
         ]);
@@ -91,20 +215,29 @@ class ContributorListTest extends TestCase
         $user = User::query()->create([
             'given_name' => 'Author',
             'family_name' => 'Tester',
-            'email' => 'author@example.test',
+            'email' => 'author-'.uniqid().'@example.test',
             'password' => 'password123456',
         ]);
 
-        $submission = Submission::withoutGlobalScopes()->forceCreate([
+        $submission = Submission::withoutGlobalScopes()->forceCreate(array_merge([
             'user_id' => $user->getKey(),
             'conference_id' => $conference->getKey(),
             'scheduled_conference_id' => $scheduledConference->getKey(),
             'track_id' => $track->getKey(),
-        ]);
+        ], $submissionOverrides));
 
         return [
+            'conference' => $conference,
             'user' => $user,
             'submission' => $submission,
         ];
+    }
+
+    protected function createAuthorRole(Conference $conference): AuthorRole
+    {
+        return AuthorRole::query()->firstOrCreate([
+            'conference_id' => $conference->getKey(),
+            'name' => 'Author',
+        ]);
     }
 }

--- a/tests/Feature/ContributorListTest.php
+++ b/tests/Feature/ContributorListTest.php
@@ -81,6 +81,10 @@ class ContributorListTest extends TestCase
         $this->actingAs($context['user']);
 
         Livewire::test(ContributorList::class, ['submission' => $context['submission']])
+            ->assertTableActionExists(
+                'addMyselfAsContributor',
+                fn ($action): bool => $action->getModalDescription() === __('filament-actions::modal.confirmation')
+            )
             ->assertTableActionVisible('addMyselfAsContributor')
             ->callTableAction('addMyselfAsContributor')
             ->assertHasNoTableActionErrors();


### PR DESCRIPTION
## Summary
- add a wizard-only contributor shortcut so submission owners can insert themselves as an author
- copy the current user's identity metadata into the author record and set primary contact when applicable
- guard duplicate clicks/requests so the same user is not inserted twice

## Tests
- `rtk php82 artisan test tests/Feature/ContributorListTest.php`
- `rtk php82 artisan test tests/Feature/TranslationCompletenessTest.php`
- `rtk php82 artisan test tests/Feature/SubmissionWizardRequiredFilesTest.php`
- `rtk php82 vendor/bin/pint --test app/Panel/ScheduledConference/Livewire/Submissions/Components/ContributorList.php tests/Feature/ContributorListTest.php`
- `rtk git diff --check`