### PR TITLE
Fix version header newline

### DIFF
--- a/app/Application.php
+++ b/app/Application.php
@@ -67,7 +67,7 @@ class Application extends LaravelApplication
 
     public function getCodeVersion(): string
     {
-        return File::get(base_path('version'));
+        return trim(File::get(base_path('version')));
     }
 
     public function getVersion()

--- a/tests/Feature/HttpClientHeaderTest.php
+++ b/tests/Feature/HttpClientHeaderTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature;
+
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class HttpClientHeaderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_leconfe_version_headers_are_safe_when_code_version_has_line_break(): void
+    {
+        File::partialMock()
+            ->shouldReceive('get')
+            ->with(base_path('version'))
+            ->andReturn("1.4.5\n");
+
+        $history = [];
+        $handler = HandlerStack::create(new MockHandler([
+            new Response(200, [], '{}'),
+        ]));
+        $handler->push(Middleware::history($history));
+
+        Http::withOptions(['handler' => $handler])->get('https://leconfe.test/plugins');
+
+        $this->assertCount(1, $history);
+        $request = $history[0]['request'];
+
+        $this->assertSame('1.4.5', $request->getHeaderLine('Leconfe-Version'));
+        $this->assertSame('Leconfe/1.4.5', $request->getHeaderLine('User-Agent'));
+    }
+}

--- a/tests/Unit/ApplicationVersionTest.php
+++ b/tests/Unit/ApplicationVersionTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+class ApplicationVersionTest extends TestCase
+{
+    public function test_code_version_trims_version_file_contents(): void
+    {
+        File::shouldReceive('get')
+            ->once()
+            ->with(base_path('version'))
+            ->andReturn("1.5.0-beta.1\n");
+
+        $this->assertSame('1.5.0-beta.1', app()->getCodeVersion());
+    }
+}


### PR DESCRIPTION
## Summary
- Backport the `1.5.x` version newline fix by trimming `Application::getCodeVersion()`.
- Add regression coverage for code version normalization and HTTP headers built from the version value.

## Root Cause
The `version` file can include a trailing newline, and `getCodeVersion()` previously returned the raw file contents. That raw value could be used in `Leconfe-Version` and `User-Agent` headers, causing Guzzle to reject the request as an invalid header value.

## Test Plan
- `rtk php82 artisan test tests/Unit/ApplicationVersionTest.php tests/Feature/HttpClientHeaderTest.php tests/Feature/UpgradePageTest.php`
- `rtk proxy git diff --cached --check`