### PR TITLE
Fix payment detail type casting

### DIFF
--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -42,6 +42,7 @@ class Payment extends Model implements HasMedia
     ];
 
     protected $casts = [
+        'type' => 'integer',
         'paid_at' => 'datetime',
     ];
 

--- a/tests/Unit/PaymentDetailTest.php
+++ b/tests/Unit/PaymentDetailTest.php
@@ -42,4 +42,14 @@ class PaymentDetailTest extends TestCase
 
         $this->assertFalse($page->shouldSendParticipantPaymentNotificationPublic($payment, []));
     }
+
+    public function test_submission_payment_title_handles_string_payment_type(): void
+    {
+        $page = new PaymentDetail;
+        $page->record = new Payment([
+            'type' => (string) PaymentManager::TYPE_SUBMISSION_FEE,
+        ]);
+
+        $this->assertSame('Submission Payment', $page->getTitle());
+    }
 }


### PR DESCRIPTION
## Summary
- cast `Payment::type` to integer so strict payment-type checks handle database-hydrated values
- add a regression test for the `PaymentDetail` title when submission payment type is hydrated as string `2`

## Root cause
`PaymentDetail::getTitle()` uses a strict PHP `match` against integer constants, but `Payment` did not cast the `type` attribute. Some production records hydrate the valid submission-payment value as the string `2`, causing `Unhandled match case '2'`.

## Validation
- `rtk php82 artisan test tests/Unit/PaymentDetailTest.php tests/Feature/SubmissionBillingNotifierTest.php`
- `rtk php82 ./vendor/bin/pint app/Models/Payment.php tests/Unit/PaymentDetailTest.php`
- `rtk git diff --check`