### PR TITLE
Allow scheduled conference invites before publish

### DIFF
--- a/app/Http/Middleware/IdentifyScheduledConference.php
+++ b/app/Http/Middleware/IdentifyScheduledConference.php
@@ -21,6 +21,10 @@ class IdentifyScheduledConference
             return abort(404);
         }
 
+        if ($this->canAccessBeforePublication($request)) {
+            return $next($request);
+        }
+
         if (Gate::allows('view', $scheduledConference)) {
             return $next($request);
         }
@@ -34,5 +38,14 @@ class IdentifyScheduledConference
         }
 
         return abort(404);
+    }
+
+    protected function canAccessBeforePublication(Request $request): bool
+    {
+        return in_array($request->route()?->getName(), [
+            'livewirePageGroup.scheduledConference.pages.invitation-accept',
+            'livewirePageGroup.scheduledConference.pages.invitation-register',
+            'livewirePageGroup.scheduledConference.pages.login',
+        ], true);
     }
 }

--- a/tests/Feature/InvitationRegisterTest.php
+++ b/tests/Feature/InvitationRegisterTest.php
@@ -6,10 +6,12 @@ use App\Frontend\Website\Pages\InvitationRegister;
 use App\Mail\Templates\VerifyUserEmail;
 use App\Models\Conference;
 use App\Models\Role;
+use App\Models\ScheduledConference;
 use App\Models\User;
 use App\Models\UserInvitation;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -30,13 +32,7 @@ class InvitationRegisterTest extends TestCase
 
         $this->createInvitationRole($conference);
 
-        $invitation = UserInvitation::query()->create([
-            'email' => 'invitee@example.com',
-            'role_name' => 'Reviewer',
-            'token' => 'invite-token-new-user',
-            'status' => 'pending',
-            'conference_id' => $conference->id,
-        ]);
+        $invitation = $this->createInvitation('invitee@example.com', 'invite-token-new-user', $conference);
 
         Livewire::test(InvitationRegister::class, ['token' => $invitation->token])
             ->set('given_name', 'Invitee')
@@ -78,13 +74,7 @@ class InvitationRegisterTest extends TestCase
             'password' => 'password12345',
         ]);
 
-        $invitation = UserInvitation::query()->create([
-            'email' => $user->email,
-            'role_name' => 'Reviewer',
-            'token' => 'invite-token-existing-user',
-            'status' => 'pending',
-            'conference_id' => $conference->id,
-        ]);
+        $invitation = $this->createInvitation($user->email, 'invite-token-existing-user', $conference);
 
         Livewire::test(InvitationRegister::class, ['token' => $invitation->token])
             ->assertRedirect(route('livewirePageGroup.conference.pages.login', [
@@ -102,12 +92,138 @@ class InvitationRegisterTest extends TestCase
         Mail::assertNothingQueued();
     }
 
-    protected function createInvitationRole(Conference $conference): void
+    public function test_scheduled_conference_invitation_registration_is_available_before_publish(): void
     {
-        Role::query()->create([
+        [$conference, $scheduledConference] = $this->createUnpublishedScheduledConferenceInvitationContext();
+        $invitation = $this->createInvitation(
+            'invitee@example.com',
+            'scheduled-invite-token-new-user',
+            $conference,
+            $scheduledConference
+        );
+
+        $this->withoutVite()
+            ->get($invitation->getRegisterUrl())
+            ->assertOk()
+            ->assertSee('Invitation Registration')
+            ->assertDontSee(__('scheduled_conference.unpublished_description'));
+    }
+
+    public function test_scheduled_conference_invitation_can_be_accepted_before_publish(): void
+    {
+        [$conference, $scheduledConference] = $this->createUnpublishedScheduledConferenceInvitationContext();
+        $user = User::factory()->create([
+            'email' => 'invitee@example.com',
+            'password' => Hash::make('password12345'),
+        ]);
+
+        $invitation = $this->createInvitation(
+            $user->email,
+            'scheduled-invite-token-existing-user',
+            $conference,
+            $scheduledConference
+        );
+
+        $this->actingAs($user)
+            ->get($invitation->getAcceptUrl())
+            ->assertRedirect(route('filament.scheduledConference.pages.dashboard', [
+                'conference' => $conference->path,
+                'serie' => $scheduledConference->path,
+            ]));
+
+        $this->assertDatabaseHas('user_invitations', [
+            'id' => $invitation->getKey(),
+            'status' => 'accepted',
+        ]);
+
+        $this->assertDatabaseHas(config('permission.table_names.model_has_roles', 'model_has_roles'), [
+            'role_id' => Role::withoutGlobalScopes()
+                ->where('name', 'Reviewer')
+                ->where('conference_id', $conference->getKey())
+                ->where('scheduled_conference_id', $scheduledConference->getKey())
+                ->firstOrFail()
+                ->getKey(),
+            'model_type' => User::class,
+            'model_id' => $user->getKey(),
+            'conference_id' => $conference->getKey(),
+            'scheduled_conference_id' => $scheduledConference->getKey(),
+        ]);
+    }
+
+    public function test_scheduled_conference_invitation_existing_user_can_reach_login_before_publish(): void
+    {
+        [$conference, $scheduledConference] = $this->createUnpublishedScheduledConferenceInvitationContext();
+        $user = User::factory()->create([
+            'email' => 'existing-invitee@example.com',
+            'password' => Hash::make('password12345'),
+        ]);
+
+        $invitation = $this->createInvitation(
+            $user->email,
+            'scheduled-invite-token-existing-user-login',
+            $conference,
+            $scheduledConference
+        );
+
+        $loginUrl = route('livewirePageGroup.scheduledConference.pages.login', [
+            'conference' => $conference->path,
+            'serie' => $scheduledConference->path,
+        ]);
+
+        $this->get($invitation->getAcceptUrl())
+            ->assertRedirect($loginUrl);
+
+        $this->withoutVite()
+            ->get($loginUrl)
+            ->assertOk()
+            ->assertSee(__('general.login'))
+            ->assertDontSee(__('scheduled_conference.unpublished_description'));
+    }
+
+    protected function createInvitationRole(Conference $conference, ?ScheduledConference $scheduledConference = null): void
+    {
+        Role::withoutGlobalScopes()->firstOrCreate([
             'name' => 'Reviewer',
-            'conference_id' => $conference->id,
             'guard_name' => 'web',
+            'conference_id' => $conference->getKey(),
+            'scheduled_conference_id' => $scheduledConference?->getKey() ?? 0,
+        ]);
+    }
+
+    protected function createUnpublishedScheduledConferenceInvitationContext(): array
+    {
+        $conference = Conference::query()->create([
+            'name' => 'Test Conference',
+            'path' => 'test-conference',
+        ]);
+
+        $scheduledConference = ScheduledConference::query()->create([
+            'conference_id' => $conference->getKey(),
+            'title' => 'Draft Scheduled Conference',
+            'path' => 'draft-scheduled-conference',
+            'is_published' => false,
+        ]);
+
+        $this->createInvitationRole($conference, $scheduledConference);
+        app()->setCurrentConferenceId($conference->getKey());
+        app()->setCurrentScheduledConferenceId($scheduledConference->getKey());
+
+        return [$conference, $scheduledConference];
+    }
+
+    protected function createInvitation(
+        string $email,
+        string $token,
+        Conference $conference,
+        ?ScheduledConference $scheduledConference = null
+    ): UserInvitation {
+        return UserInvitation::query()->create([
+            'email' => $email,
+            'role_name' => 'Reviewer',
+            'token' => $token,
+            'status' => 'pending',
+            'conference_id' => $conference->getKey(),
+            'scheduled_conference_id' => $scheduledConference?->getKey(),
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- Allow scheduled-conference invitation accept/register routes to bypass the unpublished public-page gate.
- Allow the scheduled-conference login route before publish so existing invited users can sign in from an invite link.
- Add regression coverage for new invite registration, logged-in invite acceptance, and existing-user login access before publish.

## Root Cause
`IdentifyScheduledConference` returned the unpublished placeholder page for every unpublished scheduled-conference route before invitation pages could mount, so invite links never reached the invitation accept/register logic.

## Validation
- `php82 artisan test tests/Feature/InvitationRegisterTest.php`
- `php82 artisan test tests/Feature/ScheduledConferenceAccessFlowTest.php tests/Feature/ScheduledConferenceLoginTest.php tests/Feature/InviteUserActionTest.php tests/Feature/UserInvitationTableTest.php`
- `./vendor/bin/pint --test app/Http/Middleware/IdentifyScheduledConference.php tests/Feature/InvitationRegisterTest.php`
- `php82 -l app/Http/Middleware/IdentifyScheduledConference.php`
- `php82 -l tests/Feature/InvitationRegisterTest.php`
- `git diff --check`