### PR TITLE
Fix scheduled invitation registration name

### DIFF
--- a/app/Frontend/Website/Pages/InvitationRegister.php
+++ b/app/Frontend/Website/Pages/InvitationRegister.php
@@ -2,8 +2,8 @@
 
 namespace App\Frontend\Website\Pages;
 
-use App\Actions\UserInvitation\AcceptUserInvitationAction;
 use App\Actions\User\UserCreateAction;
+use App\Actions\UserInvitation\AcceptUserInvitationAction;
 use App\Models\User;
 use App\Models\UserInvitation;
 use Filament\Facades\Filament;
@@ -110,6 +110,9 @@ class InvitationRegister extends Page
 
         return [
             'invitation' => $invitation,
+            'invitationDisplayName' => $invitation->scheduledConference?->title
+                ?? $invitation->conference?->name
+                ?? app()->getSite()->getMeta('name'),
             'privacyStatementUrl' => $invitation->scheduledConference && $invitation->conference
                 ? route('livewirePageGroup.scheduledConference.pages.privacy-statement', [
                     'conference' => $invitation->conference->path,

--- a/resources/views/frontend/website/pages/invitation-register.blade.php
+++ b/resources/views/frontend/website/pages/invitation-register.blade.php
@@ -10,7 +10,7 @@
         </div>
 
         <p class="mb-4 text-sm text-gray-700">
-            You were invited as <strong>{{ $invitation->role_name }}</strong> for <strong>{{ $invitation->conference?->name ?? app()->getSite()->getMeta('name') }}</strong>.
+            You were invited as <strong>{{ $invitation->role_name }}</strong> for <strong>{{ $invitationDisplayName }}</strong>.
         </p>
 
         <form wire:submit="register" class="space-y-4">

--- a/tests/Feature/InvitationRegisterTest.php
+++ b/tests/Feature/InvitationRegisterTest.php
@@ -106,6 +106,8 @@ class InvitationRegisterTest extends TestCase
             ->get($invitation->getRegisterUrl())
             ->assertOk()
             ->assertSee('Invitation Registration')
+            ->assertSee('for <strong>Draft Scheduled Conference</strong>', false)
+            ->assertDontSee('for <strong>Test Conference</strong>', false)
             ->assertDontSee(__('scheduled_conference.unpublished_description'));
     }
 


### PR DESCRIPTION
## Summary
- Show the scheduled conference title on invitation registration when an invitation belongs to a scheduled conference.
- Keep conference and site name fallbacks for non-scheduled invitations.
- Add regression coverage for the scheduled invitation registration page copy.

## Root cause
The invitation registration Blade view rendered the parent conference name directly, so scheduled-conference invitations displayed the conference name even though the scheduled conference context was present.

## Verification
- `php82 artisan test tests/Feature/InvitationRegisterTest.php`
- `./vendor/bin/pint --test app/Frontend/Website/Pages/InvitationRegister.php tests/Feature/InvitationRegisterTest.php`
- `php82 -l app/Frontend/Website/Pages/InvitationRegister.php`
- `php82 -l tests/Feature/InvitationRegisterTest.php`
- `git diff --check -- app/Frontend/Website/Pages/InvitationRegister.php resources/views/frontend/website/pages/invitation-register.blade.php tests/Feature/InvitationRegisterTest.php`