### PR TITLE
Fix scheduled invitation registration name for 1.4.x

### DIFF
--- a/app/Frontend/Website/Pages/InvitationRegister.php
+++ b/app/Frontend/Website/Pages/InvitationRegister.php
@@ -2,8 +2,8 @@
 
 namespace App\Frontend\Website\Pages;
 
-use App\Actions\UserInvitation\AcceptUserInvitationAction;
 use App\Actions\User\UserCreateAction;
+use App\Actions\UserInvitation\AcceptUserInvitationAction;
 use App\Models\User;
 use App\Models\UserInvitation;
 use Filament\Facades\Filament;
@@ -110,6 +110,9 @@ class InvitationRegister extends Page
 
         return [
             'invitation' => $invitation,
+            'invitationDisplayName' => $invitation->scheduledConference?->title
+                ?? $invitation->conference?->name
+                ?? app()->getSite()->getMeta('name'),
             'privacyStatementUrl' => $invitation->scheduledConference && $invitation->conference
                 ? route('livewirePageGroup.scheduledConference.pages.privacy-statement', [
                     'conference' => $invitation->conference->path,

--- a/resources/views/frontend/website/pages/invitation-register.blade.php
+++ b/resources/views/frontend/website/pages/invitation-register.blade.php
@@ -10,7 +10,7 @@
         </div>
 
         <p class="mb-4 text-sm text-gray-700">
-            You were invited as <strong>{{ $invitation->role_name }}</strong> for <strong>{{ $invitation->conference?->name ?? app()->getSite()->getMeta('name') }}</strong>.
+            You were invited as <strong>{{ $invitation->role_name }}</strong> for <strong>{{ $invitationDisplayName }}</strong>.
         </p>
 
         <form wire:submit="register" class="space-y-4">

--- a/tests/Feature/InvitationRegisterTest.php
+++ b/tests/Feature/InvitationRegisterTest.php
@@ -126,6 +126,9 @@ class InvitationRegisterTest extends TestCase
             'scheduled_conference_id' => $scheduledConference->getKey(),
         ]);
 
+        app()->setCurrentConferenceId($conference->getKey());
+        app()->setCurrentScheduledConferenceId($scheduledConference->getKey());
+
         $this->withoutVite()
             ->get($invitation->getRegisterUrl())
             ->assertOk()

--- a/tests/Feature/InvitationRegisterTest.php
+++ b/tests/Feature/InvitationRegisterTest.php
@@ -6,6 +6,7 @@ use App\Frontend\Website\Pages\InvitationRegister;
 use App\Mail\Templates\VerifyUserEmail;
 use App\Models\Conference;
 use App\Models\Role;
+use App\Models\ScheduledConference;
 use App\Models\User;
 use App\Models\UserInvitation;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -100,6 +101,37 @@ class InvitationRegisterTest extends TestCase
             'status' => 'pending',
         ]);
         Mail::assertNothingQueued();
+    }
+
+    public function test_scheduled_conference_invitation_registration_displays_scheduled_conference_name(): void
+    {
+        $conference = Conference::query()->create([
+            'name' => 'Test Conference',
+            'path' => 'test-conference',
+        ]);
+
+        $scheduledConference = ScheduledConference::query()->create([
+            'conference_id' => $conference->getKey(),
+            'title' => 'Published Scheduled Conference',
+            'path' => 'published-scheduled-conference',
+            'is_published' => true,
+        ]);
+
+        $invitation = UserInvitation::query()->create([
+            'email' => 'invitee@example.com',
+            'role_name' => 'Reviewer',
+            'token' => 'scheduled-invite-token-new-user',
+            'status' => 'pending',
+            'conference_id' => $conference->getKey(),
+            'scheduled_conference_id' => $scheduledConference->getKey(),
+        ]);
+
+        $this->withoutVite()
+            ->get($invitation->getRegisterUrl())
+            ->assertOk()
+            ->assertSee('Invitation Registration')
+            ->assertSee('for <strong>Published Scheduled Conference</strong>', false)
+            ->assertDontSee('for <strong>Test Conference</strong>', false);
     }
 
     protected function createInvitationRole(Conference $conference): void


### PR DESCRIPTION
## Summary
- Backport the scheduled invitation registration display fix to `1.4.x`.
- Show the scheduled conference title when an invitation belongs to a scheduled conference, with conference/site fallback preserved.
- Add 1.4.x-specific regression coverage for the scheduled invitation registration page copy.

## Root cause
The invitation registration Blade view rendered the parent conference name directly, so scheduled-conference invitations displayed the conference name even when scheduled conference context was present.

## Backport notes
- Cherry-picked the `1.5.x` fix from `af1aae2f`.
- Resolved the `InvitationRegisterTest.php` conflict by adding equivalent 1.4.x regression coverage instead of importing unrelated 1.5.x before-publish invitation tests.

## Verification
- `php82 artisan test tests/Feature/InvitationRegisterTest.php`
- `./vendor/bin/pint --test app/Frontend/Website/Pages/InvitationRegister.php tests/Feature/InvitationRegisterTest.php`
- `php82 -l app/Frontend/Website/Pages/InvitationRegister.php`
- `php82 -l tests/Feature/InvitationRegisterTest.php`
- `git diff --check origin/1.4.x..HEAD -- app/Frontend/Website/Pages/InvitationRegister.php resources/views/frontend/website/pages/invitation-register.blade.php tests/Feature/InvitationRegisterTest.php`