### PR TITLE
Fix invalid proceeding route parameters

### DIFF
--- a/app/Frontend/Conference/Pages/ProceedingDetail.php
+++ b/app/Frontend/Conference/Pages/ProceedingDetail.php
@@ -46,6 +46,7 @@ class ProceedingDetail extends Page
     {
         $slug = static::getSlug();
         Route::get('/proceedings/view/{proceeding}', static::class)
+            ->whereNumber('proceeding')
             ->middleware(static::getRouteMiddleware($pageGroup))
             ->withoutMiddleware(static::getWithoutRouteMiddleware($pageGroup))
             ->name((string) str($slug)->replace('/', '.'));

--- a/app/Models/Proceeding.php
+++ b/app/Models/Proceeding.php
@@ -18,7 +18,7 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 class Proceeding extends Model implements HasMedia, Sortable
 {
-    use BelongsToConference, Cachable, HasDOI, HasFactory, InteractsWithMedia, SortableTrait, Metable;
+    use BelongsToConference, Cachable, HasDOI, HasFactory, InteractsWithMedia, Metable, SortableTrait;
 
     protected $table = 'proceedings';
 
@@ -144,6 +144,22 @@ class Proceeding extends Model implements HasMedia, Sortable
             'proceeding' => $this,
             'conference' => $this->conference,
         ]);
+    }
+
+    /**
+     * Resolve the model from a route parameter.
+     *
+     * PostgreSQL rejects a non-numeric value when it is compared with this
+     * model's bigint primary key. Treat an invalid ID as a missing model so
+     * Laravel returns its normal 404 response instead.
+     */
+    public function resolveRouteBinding($value, $field = null)
+    {
+        if (($field ?? $this->getRouteKeyName()) === $this->getKeyName() && ! ctype_digit((string) $value)) {
+            return null;
+        }
+
+        return parent::resolveRouteBinding($value, $field);
     }
 
     protected function getAllDefaultMeta(): array

--- a/tests/Feature/ProceedingDetailRouteTest.php
+++ b/tests/Feature/ProceedingDetailRouteTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Proceeding;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+class ProceedingDetailRouteTest extends TestCase
+{
+    public function test_proceeding_detail_route_rejects_non_numeric_parameters(): void
+    {
+        $route = Route::getRoutes()->getByName('livewirePageGroup.conference.pages.proceeding-detail');
+
+        $this->assertSame('[0-9]+', $route->wheres['proceeding']);
+        $this->assertFalse($route->matches(Request::create('/isoph/proceedings/view/wmlMYW9iAErq1D5eRO0LoOCR7g8odUbw2PYP7d26.png'), true));
+
+        $this->assertNull(
+            (new Proceeding)->resolveRouteBinding('wmlMYW9iAErq1D5eRO0LoOCR7g8odUbw2PYP7d26.png')
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- reject non-numeric proceeding IDs at the route
- return 404 before PostgreSQL can compare a filename with a bigint ID
- add regression coverage for the rejected path

## Tests
- php82 artisan test --filter=ProceedingDetailRouteTest
- php82 ./vendor/bin/pint --test app/Frontend/Conference/Pages/ProceedingDetail.php app/Models/Proceeding.php tests/Feature/ProceedingDetailRouteTest.php