### PR TITLE
Fix website home search filter state

### DIFF
--- a/app/Frontend/Website/Pages/Home.php
+++ b/app/Frontend/Website/Pages/Home.php
@@ -22,20 +22,20 @@ class Home extends Page
         'faculty' => [
             'search' => '',
             'value' => [],
-            'options' => []
+            'options' => [],
         ],
         'category' => [
             'search' => '',
             'value' => [],
-            'options' => []
+            'options' => [],
         ],
         'search' => [
-            'value' => ''
-        ]
+            'value' => '',
+        ],
     ];
 
     protected static string|array $routeMiddleware = [
-        RedirectToConference::class
+        RedirectToConference::class,
     ];
 
     public function getTitle(): string|Htmlable
@@ -51,7 +51,7 @@ class Home extends Page
             ]);
     }
 
-    public function resetFilter(string $type = null): void
+    public function resetFilter(?string $type = null): void
     {
         if ($type) {
             $this->filter[$type]['search'] = '';
@@ -83,20 +83,22 @@ class Home extends Page
             ->published()
             ->orderBy('date_start', 'DESC');
 
-        if (!empty($this->filter['category']['value'])) {
+        if (! empty($this->filter['category']['value'])) {
             $scheduledQuery->filterByCategories($this->filter['category']['value']);
         }
 
-        if (!empty($this->filter['faculty']['value'])) {
+        if (! empty($this->filter['faculty']['value'])) {
             $scheduledQuery->whereHas('meta', function ($m) {
                 $m->where('key', 'faculty')
                     ->whereIn('value', $this->filter['faculty']['value']);
             });
         }
 
-        if ($this->filter['search']['value'] !== '') {
-            $scheduledQuery->where(function ($q) {
-                $searchTerm = '%' . mb_strtolower($this->filter['search']['value']) . '%';
+        $search = $this->filter['search']['value'] ?? '';
+
+        if ($search !== '') {
+            $scheduledQuery->where(function ($q) use ($search) {
+                $searchTerm = '%'.mb_strtolower($search).'%';
                 $q->whereRaw('LOWER(title) LIKE ?', [$searchTerm]);
             });
         }
@@ -112,7 +114,7 @@ class Home extends Page
     public function loadCategories(): void
     {
         $categories = collect(Site::getSite()->getMeta('scheduled_conference_categories', []));
-        if (!empty($this->filter['category']['search'])) {
+        if (! empty($this->filter['category']['search'])) {
             $search = $this->filter['category']['search'];
             $categories = $categories->filter(function ($value) use ($search) {
                 return stripos($value, $search) !== false;
@@ -124,7 +126,7 @@ class Home extends Page
     public function loadFaculties(): void
     {
         $faculties = collect(Site::getSite()->getMeta('scheduled_conference_faculties', []));
-        if (!empty($this->filter['faculty']['search'])) {
+        if (! empty($this->filter['faculty']['search'])) {
             $search = $this->filter['faculty']['search'];
             $faculties = $faculties->filter(function ($value) use ($search) {
                 return stripos($value, $search) !== false;
@@ -137,11 +139,13 @@ class Home extends Page
     {
         if ($name === 'filter.category.search') {
             $this->loadCategories();
+
             return;
         }
 
         if ($name === 'filter.faculty.search') {
             $this->loadFaculties();
+
             return;
         }
     }

--- a/tests/Feature/ScheduledConferencePathTest.php
+++ b/tests/Feature/ScheduledConferencePathTest.php
@@ -70,7 +70,7 @@ class ScheduledConferencePathTest extends TestCase
             'Business',
         ]);
 
-        $page = new WebsiteHome();
+        $page = new WebsiteHome;
         $page->filter['faculty']['search'] = 'med';
 
         $page->loadFaculties();
@@ -106,7 +106,7 @@ class ScheduledConferencePathTest extends TestCase
         ]);
         $medicine->setMeta('faculty', 'Medicine');
 
-        $page = new WebsiteHome();
+        $page = new WebsiteHome;
         $page->filter['faculty']['value'] = ['Engineering'];
 
         $method = new \ReflectionMethod($page, 'getViewData');
@@ -115,5 +115,20 @@ class ScheduledConferencePathTest extends TestCase
 
         $this->assertTrue($viewData['scheduledConferences']->contains($engineering));
         $this->assertFalse($viewData['scheduledConferences']->contains($medicine));
+    }
+
+    public function test_website_home_handles_a_hydrated_filter_without_search_state(): void
+    {
+        $page = new WebsiteHome;
+        $page->filter = [
+            'faculty' => ['value' => []],
+            'category' => ['value' => []],
+        ];
+
+        $method = new \ReflectionMethod($page, 'getViewData');
+        $method->setAccessible(true);
+        $viewData = $method->invoke($page);
+
+        $this->assertEmpty($viewData['scheduledConferences']);
     }
 }


### PR DESCRIPTION
## Summary
- prevent the website home Livewire component from failing when hydrated filter state lacks the search key
- add a regression test for the partial filter state

## Testing
- php82 artisan test
- php82 vendor/bin/pint --dirty