### PR TITLE
Fix default mobile dropdown child links

### DIFF
--- a/resources/views/frontend/website/components/navigation-menu-mobile/index.blade.php
+++ b/resources/views/frontend/website/components/navigation-menu-mobile/index.blade.php
@@ -67,9 +67,9 @@
                                                                     <li class="navigation-menu-item relative">
                                                                         <x-website::link @class([
                                                                             'hover:bg-base-content/10 items-center py-2 px-4 pr-6 text-sm outline-none transition-colors gap-4 w-full flex',
-                                                                            'text-primary font-semibold' => request()->url() === $item->getUrl(),
-                                                                            'text-slate-900 font-medium' => request()->url() !== $item->getUrl(),
-                                                                        ]) :href="$item->getUrl()">
+                                                                            'text-primary font-semibold' => request()->url() === $childItem->getUrl(),
+                                                                            'text-slate-900 font-medium' => request()->url() !== $childItem->getUrl(),
+                                                                        ]) :href="$childItem->getUrl()">
                                                                             {{ $childItem->getLabel() }}
                                                                         </x-website::link>
                                                                     </li>
@@ -117,9 +117,9 @@
                                                                 <li class="navigation-menu-item relative">
                                                                     <x-website::link @class([
                                                                         'hover:bg-base-content/10 items-center py-2 px-4 pr-6 text-sm outline-none transition-colors gap-4 w-full flex',
-                                                                        'text-primary font-semibold' => request()->url() === $item->getUrl(),
-                                                                        'text-slate-900 font-medium' => request()->url() !== $item->getUrl(),
-                                                                    ]) :href="$item->getUrl()">
+                                                                        'text-primary font-semibold' => request()->url() === $childItem->getUrl(),
+                                                                        'text-slate-900 font-medium' => request()->url() !== $childItem->getUrl(),
+                                                                    ]) :href="$childItem->getUrl()">
                                                                         {{ $childItem->getLabel() }}
                                                                     </x-website::link>
                                                                 </li>

--- a/tests/Feature/NavigationMenuMobileTest.php
+++ b/tests/Feature/NavigationMenuMobileTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Conference;
+use App\Models\NavigationMenu;
+use App\Models\NavigationMenuItem;
+use App\Models\ScheduledConference;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Blade;
+use Tests\TestCase;
+
+class NavigationMenuMobileTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dropdown_children_render_with_their_own_urls_for_primary_and_user_navigation(): void
+    {
+        $conference = Conference::query()->create([
+            'name' => 'Navigation Test Conference',
+            'path' => 'navigation-test-conference',
+        ]);
+        $scheduledConference = ScheduledConference::query()->create([
+            'conference_id' => $conference->getKey(),
+            'title' => '2026',
+            'path' => '2026',
+        ]);
+
+        app()->setCurrentConferenceId($conference->getKey());
+        app()->setCurrentScheduledConferenceId($scheduledConference->getKey());
+
+        $this->addDropdownItem(
+            'primary-navigation-menu',
+            'Primary parent',
+            'https://example.test/primary-parent',
+            'Primary child',
+            'https://example.test/primary-child',
+        );
+        $this->addDropdownItem(
+            'user-navigation-menu',
+            'User parent',
+            'https://example.test/user-parent',
+            'User child',
+            'https://example.test/user-child',
+        );
+
+        $html = Blade::render(
+            '<x-website::navigation-menu-mobile :headerLogo="$headerLogo" />',
+            ['headerLogo' => null],
+        );
+
+        $this->assertStringContainsString('href="https://example.test/primary-child"', $html);
+        $this->assertStringNotContainsString('href="https://example.test/primary-parent"', $html);
+        $this->assertStringContainsString('href="https://example.test/user-child"', $html);
+        $this->assertStringNotContainsString('href="https://example.test/user-parent"', $html);
+    }
+
+    private function addDropdownItem(
+        string $handle,
+        string $parentLabel,
+        string $parentUrl,
+        string $childLabel,
+        string $childUrl,
+    ): void {
+        $menu = NavigationMenu::query()
+            ->where('handle', $handle)
+            ->firstOrFail();
+        $parent = NavigationMenuItem::query()->forceCreate([
+            'navigation_menu_id' => $menu->getKey(),
+            'label' => $parentLabel,
+            'type' => 'remote-url',
+            'order_column' => 1,
+        ]);
+        $parent->setMeta('url', $parentUrl);
+
+        $child = NavigationMenuItem::query()->forceCreate([
+            'navigation_menu_id' => $menu->getKey(),
+            'parent_id' => $parent->getKey(),
+            'label' => $childLabel,
+            'type' => 'remote-url',
+            'order_column' => 1,
+        ]);
+        $child->setMeta('url', $childUrl);
+    }
+}


### PR DESCRIPTION
## Summary

- Fix Default Theme mobile dropdown children to use their own URLs.
- Correct active-link styling for primary and user navigation dropdown children.
- Add rendered regression coverage for both navigation menus.

## Root cause

The mobile navigation template rendered each child label but assigned the parent URL to every child link.

## Validation

- `php artisan test tests/Feature/NavigationMenuMobileTest.php`
- `vendor/bin/pint --test tests/Feature/NavigationMenuMobileTest.php`
- `php -l tests/Feature/NavigationMenuMobileTest.php`
- `git diff --check`
