### PR TITLE
Fix invoice queue memory exhaustion

### DIFF
--- a/app/Notifications/ParticipantPayment.php
+++ b/app/Notifications/ParticipantPayment.php
@@ -3,7 +3,7 @@
 namespace App\Notifications;
 
 use App\Mail\Templates\ParticipantPaymentMail;
-use App\Models\Participant;
+use App\Services\Billing\InvoicePaymentContextResolver;
 use Filament\Notifications\Actions\Action;
 use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Bus\Queueable;
@@ -18,9 +18,8 @@ class ParticipantPayment extends Notification implements ShouldQueue
      * Create a new notification instance.
      */
     public function __construct(
-        public Participant $participant,
-        )
-    {
+        public int $paymentId,
+    ) {
         //
     }
 
@@ -39,25 +38,32 @@ class ParticipantPayment extends Notification implements ShouldQueue
      */
     public function toMail(object $notifiable)
     {
-        return (new ParticipantPaymentMail($this->participant))
+        return (new ParticipantPaymentMail($this->participant()))
             ->to($notifiable);
     }
 
     public function toDatabase(object $notifiable)
     {
+        $participant = $this->participant();
+
         return FilamentNotification::make()
             ->icon('lineawesome-exclamation-circle-solid')
             ->iconColor('primary')
             ->title('Payment Required')
-            ->body("Participant Payment for: " . $this->participant->payment->fee->name)
+            ->body('Participant Payment for: '.$participant->payment->fee->name)
             ->actions([
                 Action::make('new-submission')
-                    ->url($this->participant->payment->getPaymentDetailUrl())
+                    ->url($participant->payment->getPaymentDetailUrl())
                     ->label('Pay')
                     ->openUrlInNewTab()
                     ->markAsRead(),
             ])
             ->getDatabaseMessage();
+    }
+
+    protected function participant()
+    {
+        return app(InvoicePaymentContextResolver::class)->participant($this->paymentId);
     }
 
     /**

--- a/app/Notifications/SubmissionPayment.php
+++ b/app/Notifications/SubmissionPayment.php
@@ -2,10 +2,8 @@
 
 namespace App\Notifications;
 
-use App\Mail\Templates\PaymentRequiredMail;
 use App\Mail\Templates\SubmissionPaymentMail;
-use App\Models\Payment;
-use App\Models\Submission;
+use App\Services\Billing\InvoicePaymentContextResolver;
 use Filament\Notifications\Actions\Action;
 use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Bus\Queueable;
@@ -20,9 +18,8 @@ class SubmissionPayment extends Notification implements ShouldQueue
      * Create a new notification instance.
      */
     public function __construct(
-        public Submission $submission,
-        )
-    {
+        public int $paymentId,
+    ) {
         //
     }
 
@@ -41,25 +38,32 @@ class SubmissionPayment extends Notification implements ShouldQueue
      */
     public function toMail(object $notifiable)
     {
-        return (new SubmissionPaymentMail($this->submission))
+        return (new SubmissionPaymentMail($this->submission()))
             ->to($notifiable);
     }
 
     public function toDatabase(object $notifiable)
     {
+        $submission = $this->submission();
+
         return FilamentNotification::make()
             ->icon('lineawesome-exclamation-circle-solid')
             ->iconColor('primary')
             ->title('Payment Required')
-            ->body('Title: '.$this->submission->payment->getMeta('title'))
+            ->body('Title: '.$submission->payment->getMeta('title'))
             ->actions([
                 Action::make('new-submission')
-                    ->url($this->submission->payment->getPaymentDetailUrl())
+                    ->url($submission->payment->getPaymentDetailUrl())
                     ->label('Pay')
                     ->openUrlInNewTab()
                     ->markAsRead(),
             ])
             ->getDatabaseMessage();
+    }
+
+    protected function submission()
+    {
+        return app(InvoicePaymentContextResolver::class)->submission($this->paymentId);
     }
 
     /**

--- a/app/Panel/ScheduledConference/Livewire/ParticipantPaymentFeeTable.php
+++ b/app/Panel/ScheduledConference/Livewire/ParticipantPaymentFeeTable.php
@@ -9,6 +9,7 @@ use App\Models\Payment;
 use App\Models\PaymentFee;
 use App\Notifications\ParticipantPayment;
 use App\Panel\ScheduledConference\Pages\PaymentDetail;
+use App\Services\Billing\InvoicePaymentContextResolver;
 use App\Tables\Columns\IndexColumn;
 use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\DatePicker;
@@ -133,8 +134,7 @@ class ParticipantPaymentFeeTable extends Component implements HasForms, HasTable
                                 return;
                             }
 
-                            $participant->setRelation('payment', $record->refresh());
-                            $participant->notify(new ParticipantPayment($participant));
+                            $participant->notify(new ParticipantPayment($record->getKey()));
                             $record->markInvoiceAsSent();
 
                             $action->successNotificationTitle(__('general.invoice_sent_successfully'));
@@ -170,24 +170,13 @@ class ParticipantPaymentFeeTable extends Component implements HasForms, HasTable
                             ->required(),
                     ])
                     ->action(function (Collection $records, array $data, BulkAction $action) {
-                        $records->load([
-                            'model',
-                            'scheduledConference.conference',
-                            'fee',
-                        ]);
-
                         $records->each(function ($record) use ($data) {
-                            $participant = $record->model;
+                            $record->ensureInvoice();
+                            $participant = app(InvoicePaymentContextResolver::class)->participant($record->getKey());
 
-                            if (! $participant || ! $participant->email) {
+                            if (! $participant->email) {
                                 return;
                             }
-
-                            $record->ensureInvoice();
-                            $participant->setRelation(
-                                'payment',
-                                $record->refresh()->loadMissing(['scheduledConference.conference', 'fee'])
-                            );
 
                             $mailTemplate = new ParticipantPaymentMail($participant);
                             $mailTemplate->subjectUsing($data['subject']);

--- a/app/Panel/ScheduledConference/Livewire/SubmissionPaymentTable.php
+++ b/app/Panel/ScheduledConference/Livewire/SubmissionPaymentTable.php
@@ -12,6 +12,7 @@ use App\Models\Submission;
 use App\Notifications\SubmissionPayment;
 use App\Panel\ScheduledConference\Pages\PaymentDetail;
 use App\Panel\ScheduledConference\Resources\SubmissionResource;
+use App\Services\Billing\InvoicePaymentContextResolver;
 use App\Tables\Columns\IndexColumn;
 use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\TextInput;
@@ -188,8 +189,7 @@ class SubmissionPaymentTable extends Component implements HasForms, HasTable
                                 return;
                             }
 
-                            $submission->setRelation('payment', $record->refresh());
-                            $submission->user->notify(new SubmissionPayment($submission));
+                            $submission->user->notify(new SubmissionPayment($record->getKey()));
                             $record->markInvoiceAsSent();
                             $action->successNotificationTitle(__('general.invoice_sent_successfully'));
                             $action->success();
@@ -217,23 +217,13 @@ class SubmissionPaymentTable extends Component implements HasForms, HasTable
                             ->required(),
                     ])
                     ->action(function (Collection $records, array $data, BulkAction $action) {
-                        $records->load([
-                            'model.user',
-                            'scheduledConference.conference',
-                        ]);
-
                         $records->each(function ($record) use ($data) {
-                            $submission = $record->model;
+                            $record->ensureInvoice();
+                            $submission = app(InvoicePaymentContextResolver::class)->submission($record->getKey());
 
-                            if (! $submission || ! $submission->user) {
+                            if (! $submission->user) {
                                 return;
                             }
-
-                            $record->ensureInvoice();
-                            $submission->setRelation(
-                                'payment',
-                                $record->refresh()->loadMissing('scheduledConference.conference')
-                            );
 
                             $mailTemplate = new SubmissionPaymentMail($submission);
 

--- a/app/Panel/ScheduledConference/Pages/ParticipantRegistration.php
+++ b/app/Panel/ScheduledConference/Pages/ParticipantRegistration.php
@@ -212,7 +212,9 @@ class ParticipantRegistration extends Page implements HasForms
 
             if (app()->getCurrentScheduledConference()->isParticipantPaymentAutoNotify()) {
                 $payment->ensureInvoice();
-                auth()->user()->notify(new ParticipantPayment($payment->getKey()));
+                auth()->user()->notify(
+                    (new ParticipantPayment($payment->getKey()))->afterCommit()
+                );
                 $payment->markInvoiceAsSent();
             }
 

--- a/app/Panel/ScheduledConference/Pages/ParticipantRegistration.php
+++ b/app/Panel/ScheduledConference/Pages/ParticipantRegistration.php
@@ -212,8 +212,7 @@ class ParticipantRegistration extends Page implements HasForms
 
             if (app()->getCurrentScheduledConference()->isParticipantPaymentAutoNotify()) {
                 $payment->ensureInvoice();
-                $participant->setRelation('payment', $payment->refresh());
-                auth()->user()->notify(new ParticipantPayment($participant));
+                auth()->user()->notify(new ParticipantPayment($payment->getKey()));
                 $payment->markInvoiceAsSent();
             }
 

--- a/app/Panel/ScheduledConference/Pages/PaymentDetail.php
+++ b/app/Panel/ScheduledConference/Pages/PaymentDetail.php
@@ -310,8 +310,7 @@ class PaymentDetail extends Page
 
             if ($participant && $record->user) {
                 $record->ensureInvoice();
-                $participant->setRelation('payment', $record->refresh());
-                $record->user->notify(new ParticipantPayment($participant));
+                $record->user->notify(new ParticipantPayment($record->getKey()));
                 $record->markInvoiceAsSent();
             }
         }
@@ -391,8 +390,7 @@ class PaymentDetail extends Page
             return;
         }
 
-        $submission->setRelation('payment', $record);
-        $submission->user->notify(new SubmissionPayment($submission));
+        $submission->user->notify(new SubmissionPayment($record->getKey()));
         $record->markInvoiceAsSent();
 
         static::successSendInvoice($action);
@@ -409,8 +407,7 @@ class PaymentDetail extends Page
             return;
         }
 
-        $participant->setRelation('payment', $record);
-        $participant->notify(new ParticipantPayment($participant));
+        $participant->notify(new ParticipantPayment($record->getKey()));
         $record->markInvoiceAsSent();
 
         static::successSendInvoice($action);

--- a/app/Services/Billing/InvoicePaymentContextResolver.php
+++ b/app/Services/Billing/InvoicePaymentContextResolver.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Services\Billing;
+
+use App\Models\Participant;
+use App\Models\Payment;
+use App\Models\Submission;
+use Illuminate\Database\Eloquent\Model;
+use LogicException;
+
+class InvoicePaymentContextResolver
+{
+    public function submission(int $paymentId): Submission
+    {
+        $model = $this->resolve($paymentId, Submission::class);
+
+        $model->loadMissing('user');
+
+        return $model;
+    }
+
+    public function participant(int $paymentId): Participant
+    {
+        return $this->resolve($paymentId, Participant::class);
+    }
+
+    /**
+     * @template TModel of Model
+     *
+     * @param  class-string<TModel>  $expectedModelClass
+     * @return TModel
+     */
+    protected function resolve(int $paymentId, string $expectedModelClass): Model
+    {
+        $payment = Payment::withoutGlobalScopes()
+            ->with(['model', 'scheduledConference.conference', 'fee'])
+            ->findOrFail($paymentId);
+
+        $model = $payment->model;
+
+        if (! $model instanceof $expectedModelClass) {
+            throw new LogicException("Payment {$paymentId} does not belong to {$expectedModelClass}.");
+        }
+
+        $payment->unsetRelation('model');
+        $model->setRelation('payment', $payment);
+
+        return $model;
+    }
+}

--- a/app/Services/Billing/SubmissionBillingNotifier.php
+++ b/app/Services/Billing/SubmissionBillingNotifier.php
@@ -77,8 +77,7 @@ class SubmissionBillingNotifier
         }
 
         $payment->ensureInvoice();
-        $submission->setRelation('payment', $payment->refresh());
-        $submission->user->notify(new SubmissionPayment($submission));
+        $submission->user->notify(new SubmissionPayment($payment->getKey()));
         $payment->markInvoiceAsSent();
         $payment->setMeta(self::PAYMENT_META_AUTO_NOTIFIED_AT, now()->toDateTimeString());
 

--- a/tests/Feature/OperationalNotificationRecipientsTest.php
+++ b/tests/Feature/OperationalNotificationRecipientsTest.php
@@ -17,6 +17,7 @@ use App\Models\Submission;
 use App\Models\Track;
 use App\Models\User;
 use App\Notifications\NewSubmission;
+use App\Notifications\ParticipantPayment;
 use App\Notifications\ParticipantRegistered;
 use App\Notifications\SubmissionWithdrawRequested;
 use App\Panel\ScheduledConference\Livewire\Wizards\SubmissionWizard\Steps\ReviewStep;
@@ -150,6 +151,29 @@ class OperationalNotificationRecipientsTest extends TestCase
 
         Notification::assertSentTo($manager, ParticipantRegistered::class);
         Notification::assertNotSentTo($admin, ParticipantRegistered::class);
+    }
+
+    public function test_participant_registration_defers_invoice_notification_until_after_commit(): void
+    {
+        $participant = $this->userWithRole(UserRole::Participant, 'invoice-participant@example.test');
+        $paymentFee = $this->createPaymentFee(PaymentManager::TYPE_PARTICIPANT_FEE);
+
+        $this->scheduledConference->setMeta('participant_payment', true);
+        Notification::fake();
+
+        $this->actingAs($participant);
+
+        Livewire::test(ParticipantRegistration::class)
+            ->set('formData.given_name', 'Invoice')
+            ->set('formData.family_name', 'Participant')
+            ->set('formData.payment_fee_id', $paymentFee->getKey())
+            ->call('submit');
+
+        Notification::assertSentTo(
+            $participant,
+            ParticipantPayment::class,
+            fn (ParticipantPayment $notification): bool => $notification->afterCommit === true,
+        );
     }
 
     public function test_participant_registration_submit_is_ignored_when_registration_is_disabled(): void

--- a/tests/Feature/SubmissionBillingNotifierTest.php
+++ b/tests/Feature/SubmissionBillingNotifierTest.php
@@ -765,7 +765,11 @@ class SubmissionBillingNotifierTest extends TestCase
             'record' => $payment,
         ]);
 
-        Notification::assertSentTo($context['user'], SubmissionPayment::class);
+        Notification::assertSentTo(
+            $context['user'],
+            SubmissionPayment::class,
+            fn (SubmissionPayment $notification): bool => $notification->paymentId === $payment->getKey(),
+        );
         $this->assertNotNull($payment->refresh()->invoice);
         $this->assertTrue($payment->hasInvoiceBeenSent());
     }
@@ -866,7 +870,11 @@ class SubmissionBillingNotifierTest extends TestCase
             'record' => $payment,
         ]);
 
-        Notification::assertSentTo($participant, ParticipantPayment::class);
+        Notification::assertSentTo(
+            $participant,
+            ParticipantPayment::class,
+            fn (ParticipantPayment $notification): bool => $notification->paymentId === $payment->getKey(),
+        );
         $this->assertNotNull($payment->refresh()->invoice);
         $this->assertTrue($payment->hasInvoiceBeenSent());
     }
@@ -935,8 +943,6 @@ class SubmissionBillingNotifierTest extends TestCase
 
         $payment = $context['submission']->payment()->with('scheduledConference.conference')->firstOrFail();
         $payment->update(['invoice' => 'INV-001']);
-        $context['submission']->setRelation('payment', $payment);
-
         (function () {
             $this->currentConferenceId = null;
             $this->currentConference = null;
@@ -945,7 +951,7 @@ class SubmissionBillingNotifierTest extends TestCase
         })->call(app());
 
         $url = $payment->getPaymentDetailUrl();
-        $notification = new SubmissionPayment($context['submission']);
+        $notification = new SubmissionPayment($payment->getKey());
         $databaseMessage = $notification->toDatabase($context['user']);
 
         $this->assertSame(
@@ -997,8 +1003,6 @@ class SubmissionBillingNotifierTest extends TestCase
         )->loadMissing(['scheduledConference.conference', 'fee']);
 
         $payment->update(['invoice' => 'INV-002']);
-        $participant->setRelation('payment', $payment);
-
         (function () {
             $this->currentConferenceId = null;
             $this->currentConference = null;
@@ -1007,7 +1011,7 @@ class SubmissionBillingNotifierTest extends TestCase
         })->call(app());
 
         $url = $payment->getPaymentDetailUrl();
-        $notification = new ParticipantPayment($participant);
+        $notification = new ParticipantPayment($payment->getKey());
         $databaseMessage = $notification->toDatabase($context['user']);
 
         $this->assertSame(
@@ -1020,6 +1024,55 @@ class SubmissionBillingNotifierTest extends TestCase
         );
         $this->assertSame($url, data_get($databaseMessage, 'actions.0.url'));
         $this->assertSame($url, data_get($notification->toMail($context['user'])->buildViewData(), 'Payment Link'));
+    }
+
+    public function test_payment_notifications_queue_only_the_payment_identifier(): void
+    {
+        $context = $this->makeSubmissionContext(
+            billingStage: SubmissionStage::PeerReview,
+            submissionStage: SubmissionStage::PeerReview,
+            submissionStatus: SubmissionStatus::OnReview,
+        );
+
+        $this->queueSubmissionPayment($context['submission'], $context['paymentFee']);
+        $submissionPayment = $context['submission']->payment()->firstOrFail();
+
+        $participant = Participant::withoutGlobalScopes()->create([
+            'given_name' => 'Participant',
+            'family_name' => 'Tester',
+            'email' => 'participant-queue@example.test',
+            'conference_id' => $context['conference']->getKey(),
+            'scheduled_conference_id' => $context['scheduledConference']->getKey(),
+        ]);
+
+        $participantPayment = PaymentManager::get()->queue(
+            $participant,
+            $context['paymentFee'],
+            $context['user'],
+            PaymentManager::TYPE_PARTICIPANT_FEE,
+            $participant->full_name,
+            '/participant/'.$participant->getKey(),
+            'Participant billing',
+        );
+
+        $submissionNotification = new SubmissionPayment($submissionPayment->getKey());
+        $participantNotification = new ParticipantPayment($participantPayment->getKey());
+        $restoredSubmissionNotification = unserialize(serialize($submissionNotification));
+        $restoredParticipantNotification = unserialize(serialize($participantNotification));
+        $restoredSubmissionJob = unserialize(serialize(new \Illuminate\Notifications\SendQueuedNotifications($context['user'], $submissionNotification, ['mail'])));
+        $restoredParticipantJob = unserialize(serialize(new \Illuminate\Notifications\SendQueuedNotifications($participant, $participantNotification, ['mail'])));
+
+        $submission = app(\App\Services\Billing\InvoicePaymentContextResolver::class)->submission($submissionPayment->getKey());
+        $resolvedParticipant = app(\App\Services\Billing\InvoicePaymentContextResolver::class)->participant($participantPayment->getKey());
+
+        $this->assertSame($submissionPayment->getKey(), $restoredSubmissionNotification->paymentId);
+        $this->assertSame($participantPayment->getKey(), $restoredParticipantNotification->paymentId);
+        $this->assertSame($submissionPayment->getKey(), $restoredSubmissionJob->notification->paymentId);
+        $this->assertSame($participantPayment->getKey(), $restoredParticipantJob->notification->paymentId);
+        $this->assertTrue($submission->relationLoaded('payment'));
+        $this->assertFalse($submission->payment->relationLoaded('model'));
+        $this->assertTrue($resolvedParticipant->relationLoaded('payment'));
+        $this->assertFalse($resolvedParticipant->payment->relationLoaded('model'));
     }
 
     protected function makeSubmissionContext(


### PR DESCRIPTION
## Summary

- queue invoice notifications using only the payment ID
- resolve minimal payment context inside the delivery worker without loading the reverse model relation
- cover submission and participant queue serialization to prevent cyclic Eloquent relation graphs

## Root cause

The notification payload held a submission or participant with `payment.model` pointing back to the same model. Laravel queue serialization recursively followed this cyclic relation graph, exhausting PHP memory before the invoice could be sent.

## Validation

- `vendor/bin/pint --test` on the touched files
- `php82 artisan test tests/Unit/PaymentDetailTest.php tests/Feature/SubmissionBillingNotifierTest.php` (31 passed, 117 assertions)