### PR TITLE
fix switch peer review round tabs

### DIFF
--- a/app/Panel/ScheduledConference/Livewire/Submissions/Components/Discussions/PeerReviewDiscussionTopic.php
+++ b/app/Panel/ScheduledConference/Livewire/Submissions/Components/Discussions/PeerReviewDiscussionTopic.php
@@ -49,12 +49,13 @@ class PeerReviewDiscussionTopic extends Component implements HasForms, HasTable,
 
     public ?int $reviewRoundId = null;
 
-    public function mount(Submission $submission, SubmissionStage $stage): void
+    public function mount(Submission $submission, SubmissionStage $stage, ?int $reviewRoundId = null): void
     {
         $this->submission = $submission;
         $this->stage = $stage;
-        $this->reviewRoundId = $submission->activeReviewRound?->getKey()
-            ?? $submission->latestReviewRound?->getKey();
+        $this->reviewRoundId = $reviewRoundId && $submission->reviewRounds()->whereKey($reviewRoundId)->exists()
+            ? $reviewRoundId
+            : ($submission->activeReviewRound?->getKey() ?? $submission->latestReviewRound?->getKey());
     }
 
     #[On('peer-review-round-selected')]

--- a/app/Panel/ScheduledConference/Livewire/Submissions/Components/Files/ReviewFiles.php
+++ b/app/Panel/ScheduledConference/Livewire/Submissions/Components/Files/ReviewFiles.php
@@ -28,11 +28,12 @@ class ReviewFiles extends SubmissionFilesTable implements HasActions
         $this->tableHeading = __('general.review_files');
     }
 
-    public function mount(Submission $submission): void
+    public function mount(Submission $submission, ?int $reviewRoundId = null): void
     {
         $this->submission = $submission;
-        $this->reviewRoundId = $submission->activeReviewRound?->getKey()
-            ?? $submission->latestReviewRound?->getKey();
+        $this->reviewRoundId = $reviewRoundId && $submission->reviewRounds()->whereKey($reviewRoundId)->exists()
+            ? $reviewRoundId
+            : ($submission->activeReviewRound?->getKey() ?? $submission->latestReviewRound?->getKey());
     }
 
     #[On('peer-review-round-selected')]

--- a/app/Panel/ScheduledConference/Livewire/Submissions/Components/Files/RevisionFiles.php
+++ b/app/Panel/ScheduledConference/Livewire/Submissions/Components/Files/RevisionFiles.php
@@ -22,11 +22,12 @@ class RevisionFiles extends SubmissionFilesTable implements HasActions
         $this->tableHeading = __('general.revisions');
     }
 
-    public function mount(Submission $submission): void
+    public function mount(Submission $submission, ?int $reviewRoundId = null): void
     {
         $this->submission = $submission;
-        $this->reviewRoundId = $submission->activeReviewRound?->getKey()
-            ?? $submission->latestReviewRound?->getKey();
+        $this->reviewRoundId = $reviewRoundId && $submission->reviewRounds()->whereKey($reviewRoundId)->exists()
+            ? $reviewRoundId
+            : ($submission->activeReviewRound?->getKey() ?? $submission->latestReviewRound?->getKey());
     }
 
     #[On('peer-review-round-selected')]

--- a/app/Panel/ScheduledConference/Livewire/Submissions/Components/ReviewerList.php
+++ b/app/Panel/ScheduledConference/Livewire/Submissions/Components/ReviewerList.php
@@ -34,9 +34,6 @@ use App\Models\Submission;
 use App\Models\SubmissionFile;
 use App\Models\SubmissionReviewRound;
 use App\Models\User;
-use App\Panel\ScheduledConference\Livewire\Submissions\Components\Discussions\PeerReviewDiscussionTopic;
-use App\Panel\ScheduledConference\Livewire\Submissions\Components\Files\ReviewFiles;
-use App\Panel\ScheduledConference\Livewire\Submissions\Components\Files\RevisionFiles;
 use App\Panel\ScheduledConference\Livewire\Submissions\PeerReview;
 use App\Panel\ScheduledConference\Resources\SubmissionResource;
 use Awcodes\Shout\Components\Shout;
@@ -81,7 +78,7 @@ class ReviewerList extends Component implements HasActions, HasForms, HasTable
 
     public ?int $selectedRoundId = null;
 
-    public function mount(Submission $record)
+    public function mount(Submission $record, ?int $selectedRoundId = null)
     {
         $this->record = $record;
         $this->reviewerRole = Role::where('name', UserRole::Reviewer->value)->first();
@@ -96,10 +93,9 @@ class ReviewerList extends Component implements HasActions, HasForms, HasTable
             $this->record->refresh();
         }
 
-        $this->selectedRoundId = $this->record->activeReviewRound?->getKey()
-            ?? $this->record->latestReviewRound?->getKey();
-
-        $this->dispatchSelectedRound();
+        $this->selectedRoundId = $selectedRoundId && $this->record->reviewRounds()->whereKey($selectedRoundId)->exists()
+            ? $selectedRoundId
+            : ($this->record->activeReviewRound?->getKey() ?? $this->record->latestReviewRound?->getKey());
     }
 
     #[On('peer-review-round-selected')]
@@ -117,7 +113,6 @@ class ReviewerList extends Component implements HasActions, HasForms, HasTable
 
         $this->selectedRoundId = $roundId;
         $this->resetTable();
-        $this->dispatchSelectedRound();
     }
 
     public function getReviewRoundsProperty(): Collection
@@ -197,28 +192,10 @@ class ReviewerList extends Component implements HasActions, HasForms, HasTable
         );
 
         $this->selectedRoundId = $round->getKey();
-        $this->dispatchSelectedRound();
-
-        return $round;
-    }
-
-    protected function dispatchSelectedRound(): void
-    {
-        if (! $this->selectedRoundId) {
-            return;
-        }
-
-        $this->dispatch('peer-review-round-selected', roundId: $this->selectedRoundId)
+        $this->dispatch('reviewer-list-round-created', roundId: $this->selectedRoundId)
             ->to(PeerReview::class);
 
-        $this->dispatch('peer-review-round-selected', roundId: $this->selectedRoundId)
-            ->to(ReviewFiles::class);
-
-        $this->dispatch('peer-review-round-selected', roundId: $this->selectedRoundId)
-            ->to(RevisionFiles::class);
-
-        $this->dispatch('peer-review-round-selected', roundId: $this->selectedRoundId)
-            ->to(PeerReviewDiscussionTopic::class);
+        return $round;
     }
 
     public function form(Schema $schema): Schema

--- a/app/Panel/ScheduledConference/Livewire/Submissions/PeerReview.php
+++ b/app/Panel/ScheduledConference/Livewire/Submissions/PeerReview.php
@@ -149,10 +149,15 @@ class PeerReview extends Component implements HasActions, HasForms
         $this->dispatchSelectedRound();
     }
 
-    #[On('peer-review-round-selected')]
-    public function onReviewRoundSelected(int $roundId): void
+    #[On('reviewer-list-round-created')]
+    public function onReviewerListRoundCreated(int $roundId): void
     {
+        if (! $this->reviewRounds->pluck('id')->contains($roundId)) {
+            return;
+        }
+
         $this->selectedRoundId = $roundId;
+        $this->dispatchSelectedRound();
     }
 
     protected function dispatchSelectedRound(): void

--- a/resources/views/panel/scheduledConference/livewire/submissions/peer-review.blade.php
+++ b/resources/views/panel/scheduledConference/livewire/submissions/peer-review.blade.php
@@ -89,22 +89,22 @@
                     ])>
                         <div class="p-4">
                             {{-- Review Files --}}
-                            @livewire(Components\Files\ReviewFiles::class, ['submission' => $submission], key('review-files-' . $submission->id . '-' . $this->selectedRoundId))
+                            @livewire(Components\Files\ReviewFiles::class, ['submission' => $submission, 'reviewRoundId' => $this->selectedRoundId], key('review-files-' . $submission->id . '-' . $this->selectedRoundId))
                         </div>
 
                         <div class="border-t border-gray-200 p-4">
                             {{-- Reviewer List --}}
-                            @livewire(Components\ReviewerList::class, ['record' => $submission], key('reviewer-list-' . $submission->id . '-' . $this->selectedRoundId))
+                            @livewire(Components\ReviewerList::class, ['record' => $submission, 'selectedRoundId' => $this->selectedRoundId], key('reviewer-list-' . $submission->id . '-' . $this->selectedRoundId))
                         </div>
 
                         <div class="border-t border-gray-200 p-4">
                             {{-- Revision Files --}}
-                            @livewire(Components\Files\RevisionFiles::class, ['submission' => $submission], key('revision-files-' . $submission->id . '-' . $this->selectedRoundId))
+                            @livewire(Components\Files\RevisionFiles::class, ['submission' => $submission, 'reviewRoundId' => $this->selectedRoundId], key('revision-files-' . $submission->id . '-' . $this->selectedRoundId))
                         </div>
 
                         <div class="border-t border-gray-200 p-4">
                             {{-- Discussions --}}
-                            @livewire(Components\Discussions\PeerReviewDiscussionTopic::class, ['submission' => $submission, 'stage' => SubmissionStage::PeerReview, 'lazy' => true], key('discussions-' . $submission->id . '-' . $this->selectedRoundId))
+                            @livewire(Components\Discussions\PeerReviewDiscussionTopic::class, ['submission' => $submission, 'stage' => SubmissionStage::PeerReview, 'reviewRoundId' => $this->selectedRoundId, 'lazy' => true], key('discussions-' . $submission->id . '-' . $this->selectedRoundId))
                         </div>
                     </div>
 

--- a/tests/Feature/SubmissionReviewRoundWorkflowTest.php
+++ b/tests/Feature/SubmissionReviewRoundWorkflowTest.php
@@ -450,6 +450,38 @@ class SubmissionReviewRoundWorkflowTest extends TestCase
             ->assertActionVisible('declineSubmissionAction');
     }
 
+    public function test_historical_review_round_is_preserved_when_child_components_are_recreated(): void
+    {
+        $context = $this->makeSubmissionContext();
+
+        $roundOne = StartSubmissionReviewRoundAction::run(
+            $context['submission'],
+            [],
+            $context['editor'],
+        );
+
+        StartSubmissionReviewRoundAction::run(
+            $context['submission'],
+            [],
+            $context['editor'],
+        );
+
+        $this->actingAs($context['editor']);
+
+        Livewire::test(ReviewFiles::class, [
+            'submission' => $context['submission'],
+            'reviewRoundId' => $roundOne->getKey(),
+        ])->assertSet('reviewRoundId', $roundOne->getKey());
+
+        Livewire::test(ReviewerList::class, [
+            'record' => $context['submission'],
+            'selectedRoundId' => $roundOne->getKey(),
+        ])
+            ->assertSet('selectedRoundId', $roundOne->getKey())
+            ->assertNotDispatched('peer-review-round-selected')
+            ->assertNotDispatched('reviewer-list-round-created');
+    }
+
     public function test_peer_review_round_switch_has_section_loading_feedback(): void
     {
         $context = $this->makeSubmissionContext();


### PR DESCRIPTION
## Summary
Fixes an issue where switching peer review round tabs resets/redirects unexpectedly to another round.

## Changes
- Preserves the currently selected peer review round state in Livewire components.
Updated tab navigation bindings in `PeerReview` components.