### PR TITLE
Fix galley upload

### DIFF
--- a/app/Actions/SubmissionGalleys/CreateSubmissionGalleyAction.php
+++ b/app/Actions/SubmissionGalleys/CreateSubmissionGalleyAction.php
@@ -2,14 +2,16 @@
 
 namespace App\Actions\SubmissionGalleys;
 
-use Throwable;
 use App\Constants\SubmissionFileCategory;
+use App\Forms\Components\SpatieMediaLibraryFileUpload;
 use App\Models\Submission;
 use App\Models\SubmissionFile;
 use App\Models\SubmissionGalley;
-use App\Forms\Components\SpatieMediaLibraryFileUpload;
 use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Lorisleiva\Actions\Concerns\AsAction;
+use Throwable;
 
 class CreateSubmissionGalleyAction
 {
@@ -17,15 +19,43 @@ class CreateSubmissionGalleyAction
 
     public function handle(Submission $submission, array $data, ?SpatieMediaLibraryFileUpload $componentMedia): SubmissionGalley
     {
+        $isRemoteUrl = (bool) data_get($data, 'is_remote_url', false);
+        $media = data_get($data, 'media');
+        $temporaryFile = null;
+
+        if (! $isRemoteUrl) {
+            if (! $componentMedia) {
+                throw new InvalidArgumentException(
+                    'A SpatieMediaLibraryFileUpload component is required when creating a local submission galley.'
+                );
+            }
+
+            if (! is_array($media) || blank(data_get($media, 'type'))) {
+                throw new InvalidArgumentException(
+                    'Media data and a file type are required when creating a local submission galley.'
+                );
+            }
+
+            $temporaryFileUpload = $componentMedia->getState();
+            $temporaryFile = $temporaryFileUpload instanceof TemporaryUploadedFile
+                ? $temporaryFileUpload
+                : (is_array($temporaryFileUpload) ? reset($temporaryFileUpload) : null);
+
+            if (! $temporaryFile instanceof TemporaryUploadedFile) {
+                throw new InvalidArgumentException(
+                    'A temporary uploaded file is required when creating a local submission galley.'
+                );
+            }
+        }
+
         try {
             DB::beginTransaction();
 
             $submissionGalley = $submission->galleys()->create($data);
 
-            if ($media = data_get($data, 'media')) {
-                $temporaryFileUpload = $componentMedia->getState();
+            if (! $isRemoteUrl) {
                 $fileName = data_get($data, 'media.name') ?? null;
-                $saveGalleyMedia = $this->saveUploadedMedia($submissionGalley, reset($temporaryFileUpload), $componentMedia, $fileName);
+                $saveGalleyMedia = $this->saveUploadedMedia($submissionGalley, $temporaryFile, $componentMedia, $fileName);
 
                 $files = SubmissionFile::create([
                     'submission_id' => $submission->id,
@@ -48,7 +78,7 @@ class CreateSubmissionGalleyAction
         return $submissionGalley;
     }
 
-    private function saveUploadedMedia(SubmissionGalley $record, $file, ?SpatieMediaLibraryFileUpload $component, ?string $customFileName = null)
+    private function saveUploadedMedia(SubmissionGalley $record, TemporaryUploadedFile $file, SpatieMediaLibraryFileUpload $component, ?string $customFileName = null)
     {
         $mediaAdder = $record->addMediaFromString($file->get());
 

--- a/app/Panel/ScheduledConference/Livewire/Submissions/Components/GalleyList.php
+++ b/app/Panel/ScheduledConference/Livewire/Submissions/Components/GalleyList.php
@@ -2,30 +2,28 @@
 
 namespace App\Panel\ScheduledConference\Livewire\Submissions\Components;
 
-use Livewire\Component;
-use Filament\Actions\Contracts\HasActions;
-use Filament\Actions\Concerns\InteractsWithActions;
-use Filament\Schemas\Components\Utilities\Get;
-use Filament\Actions\Action;
-use Filament\Schemas\Components\Utilities\Set;
-use Filament\Actions\CreateAction;
-use Throwable;
-use Filament\Actions\EditAction;
-use Filament\Actions\DeleteAction;
 use App\Actions\SubmissionGalleys\CreateSubmissionGalleyAction;
 use App\Actions\SubmissionGalleys\UpdateMediaSubmissionGalleyFileAction;
 use App\Actions\SubmissionGalleys\UpdateSubmissionGalleyAction;
 use App\Constants\SubmissionFileCategory;
+use App\Forms\Components\SpatieMediaLibraryFileUpload;
 use App\Models\Submission;
 use App\Models\SubmissionFileType;
 use App\Models\SubmissionGalley;
+use Filament\Actions\Action;
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Actions\CreateAction;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\EditAction;
 use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\Select;
-use App\Forms\Components\SpatieMediaLibraryFileUpload;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
 use Filament\Tables\Columns\Layout\Split;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Concerns\InteractsWithTable;
@@ -33,9 +31,11 @@ use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Support\HtmlString;
+use Illuminate\Validation\ValidationException;
+use Livewire\Component;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 
-class GalleyList extends Component implements HasForms, HasTable, HasActions
+class GalleyList extends Component implements HasActions, HasForms, HasTable
 {
     use InteractsWithActions;
     use InteractsWithForms, InteractsWithTable;
@@ -141,13 +141,33 @@ class GalleyList extends Component implements HasForms, HasTable, HasActions
                     if (! $mediaFile) {
                         return null;
                     }
-                    $mediaFile = reset($mediaFile) instanceof TemporaryUploadedFile
-                        ? SpatieMediaLibraryFileUpload::getClientOriginalName(reset($mediaFile))
-                        : $record->file?->media->file_name;
+                    $mediaFile = is_array($mediaFile) ? reset($mediaFile) : $mediaFile;
+                    $mediaFile = $mediaFile instanceof TemporaryUploadedFile
+                        ? SpatieMediaLibraryFileUpload::getClientOriginalName($mediaFile)
+                        : $record?->file?->media?->file_name;
 
-                    return pathinfo($mediaFile, PATHINFO_EXTENSION) ?: null;
+                    return $mediaFile ? (pathinfo($mediaFile, PATHINFO_EXTENSION) ?: null) : null;
                 }),
         ];
+    }
+
+    protected function getMountedGalleyFileUpload(): SpatieMediaLibraryFileUpload
+    {
+        $schemaName = $this->getMountedActionSchemaName();
+        $schema = filled($schemaName) ? $this->getSchema($schemaName) : null;
+        $component = $schema?->getComponent('media.files', withHidden: true);
+
+        if ($component instanceof SpatieMediaLibraryFileUpload) {
+            return $component;
+        }
+
+        $statePath = filled($schema?->getStatePath())
+            ? "{$schema->getStatePath()}.media.files"
+            : 'media.files';
+
+        throw ValidationException::withMessages([
+            $statePath => __('The galley file upload component could not be resolved. Please reload the page and try again.'),
+        ]);
     }
 
     public function table(Table $table): Table
@@ -173,19 +193,15 @@ class GalleyList extends Component implements HasForms, HasTable, HasActions
                     ->successNotificationTitle(__('general.galley_added_succesfully'))
                     ->failureNotificationTitle(__('general.there_was_problem_adding_galley'))
                     ->schema(static::getGalleyFormSchema())
-                    ->using(function (array $data, Component $livewire) {
-                        try {
-                            $componentFile = ! $data['is_remote_url'] ?
-                                $livewire->getMountedTableActionForm()->getComponent('mountedTableActionsData.0.media.files') :
-                                null;
+                    ->using(function (array $data) {
+                        $componentFile = data_get($data, 'is_remote_url', false)
+                            ? null
+                            : $this->getMountedGalleyFileUpload();
 
-                            $newGalley = CreateSubmissionGalleyAction::run($this->submission, $data, $componentFile);
+                        $newGalley = CreateSubmissionGalleyAction::run($this->submission, $data, $componentFile);
 
-                            if ($newGalley instanceof SubmissionGalley) {
-                                return $newGalley;
-                            }
-                        } catch (Throwable $th) {
-                            throw $th;
+                        if ($newGalley instanceof SubmissionGalley) {
+                            return $newGalley;
                         }
                     })
                     ->hidden($this->viewOnly),

--- a/tests/Feature/GalleyListTest.php
+++ b/tests/Feature/GalleyListTest.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Actions\SubmissionGalleys\CreateSubmissionGalleyAction;
+use App\Constants\SubmissionFileCategory;
+use App\Forms\Components\SpatieMediaLibraryFileUpload;
+use App\Models\Conference;
+use App\Models\ScheduledConference;
+use App\Models\Submission;
+use App\Models\SubmissionFile;
+use App\Models\SubmissionFileType;
+use App\Models\Track;
+use App\Models\User;
+use App\Panel\ScheduledConference\Livewire\Submissions\Components\GalleyList;
+use Filament\Actions\Testing\TestAction;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Validation\Validator;
+use InvalidArgumentException;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class GalleyListTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_creates_a_local_galley_from_an_uploaded_file(): void
+    {
+        Storage::fake('private-files');
+
+        $context = $this->makeSubmissionContext();
+        $fileType = SubmissionFileType::query()->create([
+            'name' => 'PDF',
+            'scheduled_conference_id' => $context['scheduledConference']->getKey(),
+        ]);
+
+        $this->actingAs($context['user']);
+
+        $component = Livewire::test(GalleyList::class, ['submission' => $context['submission']])
+            ->mountAction(TestAction::make('create')->table())
+            ->fillForm([
+                'label' => 'PDF',
+                'is_remote_url' => false,
+                'media' => [
+                    'type' => $fileType->getKey(),
+                    'files' => [
+                        UploadedFile::fake()->create('camera-ready.pdf', 12, 'application/pdf'),
+                    ],
+                    'is_custom_name' => true,
+                    'name' => 'custom-galley-name',
+                ],
+            ]);
+
+        $component
+            ->callMountedAction()
+            ->assertHasNoActionErrors();
+
+        $galley = $context['submission']->galleys()->with('file.media')->sole();
+
+        $this->assertNull($galley->remote_url);
+        $this->assertNotNull($galley->submission_file_id);
+        $this->assertSame('custom-galley-name.pdf', $galley->file->media->file_name);
+        $this->assertSame($fileType->getKey(), $galley->file->submission_file_type_id);
+        $this->assertSame(SubmissionFileCategory::GALLEY_FILES, $galley->file->category);
+    }
+
+    public function test_it_creates_a_remote_url_galley_without_an_upload_component(): void
+    {
+        app('validator')->resolver(
+            fn ($translator, $data, $rules, $messages, $attributes) => new ValidatorWithFakeDnsRecords(
+                $translator,
+                $data,
+                $rules,
+                $messages,
+                $attributes,
+            ),
+        );
+
+        $context = $this->makeSubmissionContext();
+
+        $this->actingAs($context['user']);
+
+        Livewire::test(GalleyListWithoutFileUpload::class, ['submission' => $context['submission']])
+            ->callAction(TestAction::make('create')->table(), [
+                'label' => 'HTML',
+                'is_remote_url' => true,
+                'remote_url' => 'https://example.com/papers/galley',
+            ])
+            ->assertHasNoActionErrors();
+
+        $galley = $context['submission']->galleys()->sole();
+
+        $this->assertSame('https://example.com/papers/galley', $galley->remote_url);
+        $this->assertNull($galley->submission_file_id);
+        $this->assertSame(0, SubmissionFile::query()->count());
+    }
+
+    public function test_it_reports_a_validation_error_when_the_local_galley_upload_component_is_missing(): void
+    {
+        $context = $this->makeSubmissionContext();
+        $fileType = SubmissionFileType::query()->create([
+            'name' => 'PDF',
+            'scheduled_conference_id' => $context['scheduledConference']->getKey(),
+        ]);
+
+        $this->actingAs($context['user']);
+
+        Livewire::test(GalleyListWithoutFileUpload::class, ['submission' => $context['submission']])
+            ->callAction(TestAction::make('create')->table(), [
+                'label' => 'PDF',
+                'is_remote_url' => false,
+                'media' => [
+                    'type' => $fileType->getKey(),
+                ],
+            ])
+            ->assertHasActionErrors(['media.files']);
+
+        $this->assertSame(0, $context['submission']->galleys()->count());
+        $this->assertSame(0, SubmissionFile::query()->count());
+
+        try {
+            CreateSubmissionGalleyAction::run($context['submission'], [
+                'label' => 'PDF',
+                'is_remote_url' => false,
+                'media' => [
+                    'type' => $fileType->getKey(),
+                ],
+            ], null);
+
+            $this->fail('The create action accepted a local galley without an upload component.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame(
+                'A SpatieMediaLibraryFileUpload component is required when creating a local submission galley.',
+                $exception->getMessage(),
+            );
+        }
+
+        $this->assertSame(0, $context['submission']->galleys()->count());
+    }
+
+    /**
+     * @return array{
+     *     scheduledConference: ScheduledConference,
+     *     submission: Submission,
+     *     user: User
+     * }
+     */
+    private function makeSubmissionContext(): array
+    {
+        $conference = Conference::query()->create([
+            'name' => 'Conference '.uniqid(),
+            'path' => 'conference-'.uniqid(),
+        ]);
+
+        $scheduledConference = ScheduledConference::withoutGlobalScopes()->create([
+            'conference_id' => $conference->getKey(),
+            'title' => 'Scheduled Conference '.uniqid(),
+            'path' => 'scheduled-conference-'.uniqid(),
+            'date_start' => now()->toDateString(),
+            'date_end' => now()->addDays(2)->toDateString(),
+        ]);
+
+        app()->setCurrentConferenceId($conference->getKey());
+        app()->setCurrentScheduledConferenceId($scheduledConference->getKey());
+
+        $track = Track::withoutGlobalScopes()->create([
+            'scheduled_conference_id' => $scheduledConference->getKey(),
+            'title' => 'Track',
+            'abbreviation' => 'TRK',
+            'is_active' => true,
+        ]);
+
+        $user = User::query()->create([
+            'given_name' => 'Author',
+            'family_name' => 'Tester',
+            'email' => 'author-'.uniqid().'@example.test',
+            'password' => 'password123456',
+        ]);
+
+        $submission = Submission::withoutGlobalScopes()->forceCreate([
+            'user_id' => $user->getKey(),
+            'conference_id' => $conference->getKey(),
+            'scheduled_conference_id' => $scheduledConference->getKey(),
+            'track_id' => $track->getKey(),
+        ]);
+
+        return compact('scheduledConference', 'submission', 'user');
+    }
+}
+
+class GalleyListWithoutFileUpload extends GalleyList
+{
+    public function getGalleyFormSchema(): array
+    {
+        return array_values(array_filter(
+            parent::getGalleyFormSchema(),
+            fn ($component): bool => ! $component instanceof SpatieMediaLibraryFileUpload,
+        ));
+    }
+}
+
+class ValidatorWithFakeDnsRecords extends Validator
+{
+    protected function getDnsRecords($hostname, $type): array
+    {
+        return [['ip' => '192.0.2.1']];
+    }
+}


### PR DESCRIPTION
  ## Summary

  Fix Filament 5 compatibility for submission galley uploads.

  The previous implementation searched for the upload component using the legacy
  `mountedTableActionsData.0.media.files` path. Under Filament 5, this returned
  `null` and caused a `getState()` call on `null` when creating a local galley.

  ## Changes

  - Resolve the file upload component from the Filament 5 mounted action schema.
  - Validate missing upload components and temporary files before persistence.
  - Handle local file and remote URL galleys independently.
  - Support both single and array temporary upload states.
  - Improve null safety when displaying galley file extensions.
  - Add feature tests for local uploads, remote URLs, and missing components.

  ## Testing

  ```bash
  php artisan test tests/Feature/GalleyListTest.php