### PR TITLE
add border-gray-200 to sidebar manager items

### DIFF
--- a/resources/views/panel/administration/livewire/sidebar-setting.blade.php
+++ b/resources/views/panel/administration/livewire/sidebar-setting.blade.php
@@ -15,9 +15,9 @@
                     <template x-for="sidebar in items" :key="sidebar.id">
                         <div class="sidebar-item" data-sortable-item :data-id="sidebar.id">
                             <div class="relative group">
-                                <div class="flex items-center gap-2 bg-white border rounded-xl">
+                                <div class="flex items-center gap-2 bg-white border border-gray-200 rounded-xl">
                                     <button type="button"
-                                        class="p-3 text-sm text-gray-500 border-r bg-gray-50 rounded-l-xl hover:text-gray-900"
+                                        class="p-3 text-sm text-gray-500 border-r border-gray-200 bg-gray-50 rounded-l-xl hover:text-gray-900"
                                         data-sortable-handle>
                                         <x-heroicon-s-arrows-up-down class="w-4 h-4" />
                                     </button>


### PR DESCRIPTION
### Summary
    Add explicit `border-gray-200` color styling to sidebar manager item cards and drag handle buttons in `sidebar-setting.blade.php`.
  
    ### Changes
    - Updated item container and drag handle borders in `resources/views/panel/administration/livewire/sidebar-setting.blade.php` to use `border-gray-200`.
    - Fixes harsh default border rendering on the Sidebars Manager admin page.