### PR TITLE
Fix Peer Review mobile layout

### DIFF
--- a/app/Panel/ScheduledConference/Livewire/Submissions/Components/Files/SubmissionFilesTable.php
+++ b/app/Panel/ScheduledConference/Livewire/Submissions/Components/Files/SubmissionFilesTable.php
@@ -67,9 +67,11 @@ abstract class SubmissionFilesTable extends \Livewire\Component implements HasFo
     {
         return [
             TextColumn::make('id')
+                ->visibleFrom('md')
                 ->wrap(),
             TextColumn::make('media.original_file_name')
                 ->wrap()
+                ->extraAttributes(['class' => 'break-all'])
                 ->label(__('general.filename'))
                 ->color('primary')
                 ->action(function (SubmissionFile $record) {
@@ -83,6 +85,7 @@ abstract class SubmissionFilesTable extends \Livewire\Component implements HasFo
                 })
                 ->description(fn (SubmissionFile $record) => $record->type->name),
             TextColumn::make('created_at')
+                ->visibleFrom('md')
                 ->label(__('general.uploaded_at'))
                 ->formatStateUsing(fn ($state) => $state?->format(Setting::get('format_date').' '.Setting::get('format_time')))
                 ->sortable(),

--- a/app/Panel/ScheduledConference/Livewire/Submissions/Components/ReviewerAssignedFiles.php
+++ b/app/Panel/ScheduledConference/Livewire/Submissions/Components/ReviewerAssignedFiles.php
@@ -36,6 +36,8 @@ class ReviewerAssignedFiles extends \Livewire\Component implements HasForms, Has
             )
             ->columns([
                 TextColumn::make('submissionFile.media.original_file_name')
+                    ->wrap()
+                    ->extraAttributes(['class' => 'break-all'])
                     ->color('primary')
                     ->action(function (ReviewerAssignedFile $record) {
                         return Response::download(

--- a/app/Panel/ScheduledConference/Livewire/Submissions/Components/ReviewerFiles.php
+++ b/app/Panel/ScheduledConference/Livewire/Submissions/Components/ReviewerFiles.php
@@ -87,6 +87,8 @@ class ReviewerFiles extends \Livewire\Component implements HasForms, HasTable
             )
             ->columns([
                 TextColumn::make('file_name')
+                    ->wrap()
+                    ->extraAttributes(['class' => 'break-all'])
                     ->color('primary')
                     ->action(
                         fn (Media $record) => $record

--- a/app/Panel/ScheduledConference/Resources/SubmissionResource/Pages/ViewSubmission.php
+++ b/app/Panel/ScheduledConference/Resources/SubmissionResource/Pages/ViewSubmission.php
@@ -481,6 +481,9 @@ class ViewSubmission extends Page implements HasForms, HasInfolists
                             ->schema([
                                 StageTabs::make()
                                     ->contained(true)
+                                    ->extraAttributes([
+                                        'class' => 'submission-workflow-stage-tabs',
+                                    ])
                                     ->activeTab(function () {
                                         return match ($this->record->stage) {
                                             SubmissionStage::CallforAbstract => 1,

--- a/resources/panel/css/panel.css
+++ b/resources/panel/css/panel.css
@@ -30,6 +30,20 @@
     @apply font-semibold;
 }
 
+@media (max-width: 639px) {
+    .submission-workflow-stage-tabs > .fi-tabs {
+        @apply grid grid-cols-2 gap-1 overflow-visible;
+    }
+
+    .submission-workflow-stage-tabs > .fi-tabs .fi-tabs-item {
+        @apply min-h-11 min-w-0 whitespace-normal;
+    }
+
+    .submission-workflow-stage-tabs > .fi-tabs .fi-tabs-item-label {
+        @apply text-center;
+    }
+}
+
 .fi-simple-link {
     @apply text-primary-600 underline transition hover:text-primary-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-600 focus-visible:ring-offset-2 dark:text-primary-400 dark:hover:text-primary-300 dark:focus-visible:ring-primary-500;
 }


### PR DESCRIPTION
## Summary
- make the Submission Resource workflow tabs usable on mobile
- hide secondary review-file metadata below the medium breakpoint
- wrap long file names without widening reviewer tables

## Root cause
Peer Review rendered desktop-width tabs and file-table columns on narrow viewports, while unbroken file names determined an oversized table width.

## Validation
- npm run build
- php artisan test --filter=SubmissionReviewRoundWorkflowTest
- browser verification at 375px viewport