### PR TITLE
Fix static page browser title

### DIFF
--- a/app/Frontend/Website/Pages/StaticPage.php
+++ b/app/Frontend/Website/Pages/StaticPage.php
@@ -3,6 +3,7 @@
 namespace App\Frontend\Website\Pages;
 
 use App\Models\StaticPage as StaticPageModel;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Facades\Route;
 use Rahmanramsi\LivewirePageGroup\PageGroup;
 
@@ -13,6 +14,11 @@ class StaticPage extends Page
     public StaticPageModel $staticPage;
 
     public function mount() {}
+
+    public function getTitle(): string|Htmlable
+    {
+        return $this->staticPage->title;
+    }
 
     protected function getViewData(): array
     {

--- a/tests/Feature/StaticPageTest.php
+++ b/tests/Feature/StaticPageTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Frontend\Website\Pages\StaticPage as WebsiteStaticPage;
+use App\Models\StaticPage as StaticPageModel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StaticPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_static_page_uses_created_title_for_browser_title(): void
+    {
+        $staticPage = StaticPageModel::withoutGlobalScopes()->create([
+            'conference_id' => 0,
+            'scheduled_conference_id' => 0,
+            'title' => 'Research Ethics',
+            'slug' => 'research-ethics',
+        ]);
+
+        $this->withoutVite()
+            ->get(route(WebsiteStaticPage::getRouteName('website'), [
+                'staticPage' => $staticPage->slug,
+            ]))
+            ->assertOk()
+            ->assertSee('<title>Research Ethics -', false)
+            ->assertDontSee('<title>Static Page -', false);
+    }
+}


### PR DESCRIPTION
## Summary

- Use the user-created static page title for the browser tab title.
- Add HTTP regression coverage for the public static page route.

## Root cause

The shared frontend page renderer passed `getTitle()` to Livewire's page title. Static pages inherited the base fallback, which derives `Static Page` from the component class name instead of using the saved page title.

## Validation

- `php artisan test tests/Feature/StaticPageTest.php tests/Feature/WebsiteLoginTest.php tests/Feature/ScheduledConferencePrivacyStatementTest.php`
- `./vendor/bin/pint --test app/Frontend/Website/Pages/StaticPage.php tests/Feature/StaticPageTest.php`
- `git diff --check`