### PR TITLE
Scope announcement emails to scheduled conference

### DIFF
--- a/app/Actions/Announcements/AnnouncementBroadcastMail.php
+++ b/app/Actions/Announcements/AnnouncementBroadcastMail.php
@@ -15,10 +15,23 @@ class AnnouncementBroadcastMail
 
     public function handle(Announcement $announcement)
     {
+        $modelHasRolesTable = config('permission.table_names.model_has_roles', 'model_has_roles');
+        $scheduledConference = $announcement->scheduledConference()
+            ->withoutGlobalScopes()
+            ->firstOrFail();
+
         // Filter by users subscribed to announcement emails.
         $users = User::query()
             ->with('meta')
-            ->whereDoesntHave('roles', fn ($query) => $query->where('name', UserRole::Admin->value))
+            ->whereHas('roles', fn ($query) => $query
+                ->withoutGlobalScopes()
+                ->where('roles.conference_id', $scheduledConference->conference_id)
+                ->whereIn('roles.scheduled_conference_id', [0, $scheduledConference->getKey()])
+                ->whereColumn('roles.conference_id', "{$modelHasRolesTable}.conference_id")
+                ->whereColumn('roles.scheduled_conference_id', "{$modelHasRolesTable}.scheduled_conference_id"))
+            ->whereDoesntHave('roles', fn ($query) => $query
+                ->withoutGlobalScopes()
+                ->where('roles.name', UserRole::Admin->value))
             ->whereMeta('enable_new_announcement_email', true)
             ->notBanned()
             ->lazy();

--- a/tests/Feature/OperationalNotificationRecipientsTest.php
+++ b/tests/Feature/OperationalNotificationRecipientsTest.php
@@ -25,6 +25,7 @@ use App\Panel\ScheduledConference\Pages\ParticipantRegistration;
 use App\Panel\ScheduledConference\Resources\SubmissionResource\Pages\ViewSubmission;
 use App\Services\Notifications\OperationalNotificationRecipients;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Route;
@@ -277,6 +278,75 @@ class OperationalNotificationRecipientsTest extends TestCase
         Mail::assertNotQueued(
             NewAnnouncementMail::class,
             fn (NewAnnouncementMail $mail): bool => $mail->hasTo($adminManager->email)
+        );
+    }
+
+    public function test_announcement_broadcast_only_sends_to_users_in_the_scheduled_conference(): void
+    {
+        $participant = $this->userWithRole(UserRole::Participant, 'participant@example.test');
+        $otherScheduledConference = ScheduledConference::factory()->create([
+            'conference_id' => $this->conference->getKey(),
+            'path' => 'other-operational-notifications-2026',
+        ]);
+        $otherParticipantRole = Role::withoutGlobalScopes()
+            ->where('name', UserRole::Participant->value)
+            ->where('conference_id', $this->conference->getKey())
+            ->where('scheduled_conference_id', $otherScheduledConference->getKey())
+            ->firstOrFail();
+        $otherParticipant = User::factory()->create([
+            'email' => 'other-participant@example.test',
+            'password' => 'password123456',
+        ]);
+        $otherParticipant->assignRole($otherParticipantRole);
+        $announcement = Announcement::withoutGlobalScopes()->forceCreate([
+            'scheduled_conference_id' => $this->scheduledConference->getKey(),
+            'title' => 'Program update',
+        ]);
+
+        Mail::fake();
+
+        app(AnnouncementBroadcastMail::class)->handle($announcement);
+
+        Mail::assertQueued(
+            NewAnnouncementMail::class,
+            fn (NewAnnouncementMail $mail): bool => $mail->hasTo($participant->email)
+        );
+        Mail::assertNotQueued(
+            NewAnnouncementMail::class,
+            fn (NewAnnouncementMail $mail): bool => $mail->hasTo($otherParticipant->email)
+        );
+    }
+
+    public function test_announcement_broadcast_respects_the_role_assignment_scope(): void
+    {
+        $otherScheduledConference = ScheduledConference::factory()->create([
+            'conference_id' => $this->conference->getKey(),
+            'path' => 'other-role-assignment-2026',
+        ]);
+        $participantRole = $this->role(UserRole::Participant);
+        $participant = User::factory()->create([
+            'email' => 'wrongly-scoped-participant@example.test',
+            'password' => 'password123456',
+        ]);
+        DB::table('model_has_roles')->insert([
+            'role_id' => $participantRole->getKey(),
+            'conference_id' => $this->conference->getKey(),
+            'scheduled_conference_id' => $otherScheduledConference->getKey(),
+            'model_type' => User::class,
+            'model_id' => $participant->getKey(),
+        ]);
+        $announcement = Announcement::withoutGlobalScopes()->forceCreate([
+            'scheduled_conference_id' => $this->scheduledConference->getKey(),
+            'title' => 'Program update',
+        ]);
+
+        Mail::fake();
+
+        app(AnnouncementBroadcastMail::class)->handle($announcement);
+
+        Mail::assertNotQueued(
+            NewAnnouncementMail::class,
+            fn (NewAnnouncementMail $mail): bool => $mail->hasTo($participant->email)
         );
     }
 


### PR DESCRIPTION
## Summary
- scope announcement recipients to roles belonging to the announcement conference and scheduled conference
- require the role and role-assignment pivot context to match, preventing stale or cross-event assignments from receiving mail
- preserve conference managers, account-level Admin exclusion, subscription preferences, and banned-user exclusion
- add regressions for other-event recipients and mismatched assignment scopes

## Root cause
The recipient query excluded Admin accounts but otherwise admitted subscribed non-Admin users without proving that their role assignment belonged to the scheduled conference sending the announcement. The role check also needed to verify the assignment pivot scope, not only the role row.

## Validation
- `rtk php artisan test tests/Feature/OperationalNotificationRecipientsTest.php` (10 passed, 26 assertions; 2 dependency deprecation notices)
- `rtk php vendor/bin/pint --test app/Actions/Announcements/AnnouncementBroadcastMail.php tests/Feature/OperationalNotificationRecipientsTest.php`
- PHP syntax checks passed for both changed files
- `rtk git diff origin/1.5.x...HEAD --check`
- manual Mail fake matrix: same-event participant and conference manager included; other-event participant, no-role user, Admin, banned user, opted-out user, and mismatched assignment pivot excluded