### PR TITLE
Restrict announcement conference-scoped recipients

### DIFF
--- a/app/Actions/Announcements/AnnouncementBroadcastMail.php
+++ b/app/Actions/Announcements/AnnouncementBroadcastMail.php
@@ -26,7 +26,13 @@ class AnnouncementBroadcastMail
             ->whereHas('roles', fn ($query) => $query
                 ->withoutGlobalScopes()
                 ->where('roles.conference_id', $scheduledConference->conference_id)
-                ->whereIn('roles.scheduled_conference_id', [0, $scheduledConference->getKey()])
+                ->where(function ($query) use ($scheduledConference) {
+                    $query->where('roles.scheduled_conference_id', $scheduledConference->getKey())
+                        ->orWhere(function ($query) {
+                            $query->where('roles.name', UserRole::ConferenceManager->value)
+                                ->where('roles.scheduled_conference_id', 0);
+                        });
+                })
                 ->whereColumn('roles.conference_id', "{$modelHasRolesTable}.conference_id")
                 ->whereColumn('roles.scheduled_conference_id', "{$modelHasRolesTable}.scheduled_conference_id"))
             ->whereDoesntHave('roles', fn ($query) => $query

--- a/tests/Feature/OperationalNotificationRecipientsTest.php
+++ b/tests/Feature/OperationalNotificationRecipientsTest.php
@@ -317,6 +317,35 @@ class OperationalNotificationRecipientsTest extends TestCase
         );
     }
 
+    public function test_announcement_broadcast_excludes_non_manager_conference_scoped_roles(): void
+    {
+        $conferenceScopedRole = Role::withoutGlobalScopes()->firstOrCreate([
+            'name' => 'Conference Observer',
+            'guard_name' => 'web',
+            'conference_id' => $this->conference->getKey(),
+            'scheduled_conference_id' => 0,
+        ]);
+        $participant = User::factory()->create([
+            'email' => 'conference-scoped-participant@example.test',
+            'password' => 'password123456',
+        ]);
+        $participant->assignRole($conferenceScopedRole);
+        $participant->setMeta('enable_new_announcement_email', true);
+        $announcement = Announcement::withoutGlobalScopes()->forceCreate([
+            'scheduled_conference_id' => $this->scheduledConference->getKey(),
+            'title' => 'Program update',
+        ]);
+
+        Mail::fake();
+
+        app(AnnouncementBroadcastMail::class)->handle($announcement);
+
+        Mail::assertNotQueued(
+            NewAnnouncementMail::class,
+            fn (NewAnnouncementMail $mail): bool => $mail->hasTo($participant->email)
+        );
+    }
+
     public function test_announcement_broadcast_respects_the_role_assignment_scope(): void
     {
         $otherScheduledConference = ScheduledConference::factory()->create([


### PR DESCRIPTION
## Summary
- allow direct roles assigned to the announcement's scheduled conference
- preserve Conference Manager recipients across scheduled conferences in the same conference
- exclude subscribed users who only hold a conference-scoped non-manager or custom role
- add regression coverage for the remaining recipient leak after #858

## Root cause
PR #858 treated every role with `scheduled_conference_id = 0` as eligible for every scheduled conference in the same conference. That scope is valid for Conference Manager, but it also admitted conference-scoped non-manager and custom roles whose users were not members of the target scheduled conference.

## Validation
- `rtk php artisan test tests/Feature/OperationalNotificationRecipientsTest.php` (11 passed, 27 assertions; 2 dependency/PHP 8.5 deprecation notices)
- PHP syntax checks passed for both changed files
- Pint passed for both changed files
- `rtk git diff origin/1.5.x...HEAD --check`
- exact-SHA review: goal, QA, code quality, security, and context lanes all passed
- independent `AnnouncementCreateAction::run(..., true)` runtime matrix using SQLite in-memory, `MAIL_MAILER=log`, and sync queue emitted only target participant, target author, and Conference Manager; conference-scoped custom role, other-event, mismatched pivot, no-role, opted-out, banned, and Admin fixtures were excluded