### PR TITLE
Add configurable contributor profile links

### DIFF
--- a/app/Panel/Conference/Livewire/Forms/Conferences/ContributorForm.php
+++ b/app/Panel/Conference/Livewire/Forms/Conferences/ContributorForm.php
@@ -77,20 +77,14 @@ class ContributorForm extends Component
             Forms\Components\Fieldset::make(__('general.scholar_profile'))
                 ->schema([
                     Forms\Components\Grid::make(2)
-                        ->schema([
-                            Forms\Components\TextInput::make('meta.orcid_url')
-                                ->prefixIcon('academicon-orcid')
-                                ->url()
-                                ->label(__('general.orcid_id')),
-                            Forms\Components\TextInput::make('meta.google_scholar_url')
-                                ->prefixIcon('academicon-google-scholar')
-                                ->url()
-                                ->label(__('general.google_scholar')),
-                            Forms\Components\TextInput::make('meta.scopus_url')
-                                ->label(__('general.scopus_id'))
-                                ->url()
-                                ->prefixIcon('academicon-scopus-square'),
-                        ]),
+                        ->schema(
+                            collect(config('app.contributor_profile_links', []))
+                                ->map(fn (array $profile) => Forms\Components\TextInput::make('meta.'.$profile['meta'])
+                                    ->prefixIcon($profile['form_icon'] ?? $profile['icon'])
+                                    ->url()
+                                    ->label(__($profile['label'])))
+                                ->all()
+                        ),
                 ]),
         ];
     }

--- a/config/app.php
+++ b/config/app.php
@@ -18,6 +18,39 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Contributor Profile Links
+    |--------------------------------------------------------------------------
+    */
+    'contributor_profile_links' => [
+        'orcid' => [
+            'meta' => 'orcid_url',
+            'icon' => 'academicon-orcid',
+            'label' => 'general.orcid_id',
+            'color' => '#A1C837',
+        ],
+        'google_scholar' => [
+            'meta' => 'google_scholar_url',
+            'icon' => 'academicon-google-scholar',
+            'label' => 'general.google_scholar',
+            'color' => '#4185F4',
+        ],
+        'research_gate' => [
+            'meta' => 'research_gate_url',
+            'icon' => 'academicon-researchgate',
+            'label' => 'general.research_gate',
+            'color' => '#00CCBB',
+        ],
+        'scopus' => [
+            'meta' => 'scopus_url',
+            'icon' => 'academicon-scopus',
+            'form_icon' => 'academicon-scopus-square',
+            'label' => 'general.scopus_id',
+            'color' => '#e9711c',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Name
     |--------------------------------------------------------------------------
     |

--- a/lang/ar/general.php
+++ b/lang/ar/general.php
@@ -299,6 +299,7 @@ return [
     'scholar_profile' => 'ملف تعريف الباحث',
     'orcid_id' => 'ORCID',
     'google_scholar' => 'Google Scholar',
+    'research_gate' => 'ResearchGate',
     'scopus_id' => 'Scopus',
     'phone_format_international' => 'التنسيق الدولي، مثل +6281234567890',
     'roles' => 'الأدوار',

--- a/lang/en/general.php
+++ b/lang/en/general.php
@@ -305,6 +305,7 @@ return [
     'scholar_profile' => 'Scholar Profile',
     'orcid_id' => 'ORCID',
     'google_scholar' => 'Google Scholar',
+    'research_gate' => 'ResearchGate',
     'scopus_id' => 'Scopus',
     'phone_format_international' => 'International format, e.g. +6281234567890',
     'roles' => 'Roles',

--- a/lang/id/general.php
+++ b/lang/id/general.php
@@ -291,6 +291,7 @@ return [
     'scholar_profile' => 'Profil Akademik',
     'orcid_id' => 'ORCID',
     'google_scholar' => 'Google Scholar',
+    'research_gate' => 'ResearchGate',
     'scopus_id' => 'Scopus',
     'phone_format_international' => 'Format internasional, misalnya +6281234567890',
     'roles' => 'Peran',

--- a/lang/ru/general.php
+++ b/lang/ru/general.php
@@ -288,6 +288,7 @@ return [
     'scholar_profile' => 'Научный профиль',
     'orcid_id' => 'ORCID',
     'google_scholar' => 'Google Scholar',
+    'research_gate' => 'ResearchGate',
     'scopus_id' => 'Scopus',
     'phone_format_international' => 'В международном формате, напр. +998901234567',
     'roles' => 'Роли',

--- a/lang/sq/general.php
+++ b/lang/sq/general.php
@@ -287,6 +287,7 @@ return [
     'scholar_profile' => 'Profili Akademik',
     'orcid_id' => 'ORCID',
     'google_scholar' => 'Google Scholar',
+    'research_gate' => 'ResearchGate',
     'scopus_id' => 'Scopus',
     'phone_format_international' => 'Format ndërkombëtar, p.sh. +6281234567890',
     'roles' => 'Rolat',

--- a/lang/uz/general.php
+++ b/lang/uz/general.php
@@ -288,6 +288,7 @@ return [
     'scholar_profile' => 'Ilmiy profil',
     'orcid_id' => 'ORCID',
     'google_scholar' => 'Google Scholar',
+    'research_gate' => 'ResearchGate',
     'scopus_id' => 'Scopus',
     'phone_format_international' => 'Xalqaro formatda, masalan: +998901234567',
     'roles' => 'Rollar',

--- a/resources/frontend/css/frontend.css
+++ b/resources/frontend/css/frontend.css
@@ -145,20 +145,8 @@
 } */
 
 
-.orcid-logo {
-	color: #A1C837;
-	height: 1.25rem;
-	width: 1.25rem;
-}
-
-.google-scholar-logo {
-	color: #4185F4;
-	height: 1.25rem;
-	width: 1.25rem;
-}
-
-.scopus-logo {
-	color: #e9711c;
+.contributor-profile-logo {
+	color: var(--contributor-profile-color, currentColor);
 	height: 1.25rem;
 	width: 1.25rem;
 }

--- a/resources/views/frontend/scheduledConference/components/contributor-profile-links.blade.php
+++ b/resources/views/frontend/scheduledConference/components/contributor-profile-links.blade.php
@@ -1,0 +1,22 @@
+@php
+    $profileLinks = collect(config('app.contributor_profile_links', []))
+        ->map(fn (array $profile): array => [
+            ...$profile,
+            'url' => $person->getMeta($profile['meta']),
+        ])
+        ->filter(fn (array $profile): bool => filled($profile['url']));
+@endphp
+
+@if ($profileLinks->isNotEmpty())
+    <div class="cf-contributor-profile-links flex flex-wrap items-center gap-1">
+        @foreach ($profileLinks as $profile)
+            <a href="{{ $profile['url'] }}" target="_blank">
+                <x-dynamic-component
+                    :component="$profile['icon']"
+                    class="contributor-profile-logo"
+                    style="--contributor-profile-color: {{ $profile['color'] }}"
+                />
+            </a>
+        @endforeach
+    </div>
+@endif

--- a/resources/views/frontend/scheduledConference/pages/committees.blade.php
+++ b/resources/views/frontend/scheduledConference/pages/committees.blade.php
@@ -22,26 +22,7 @@
                                             <div class="cf-committee-affiliation text-xs text-gray-700">
                                                 {{ $committee->getMeta('affiliation') }}</div>
                                         @endif
-                                        @if ($committee->getMeta('scopus_url') || $committee->getMeta('google_scholar_url') || $committee->getMeta('orcid_url'))
-                                            <div class="cf-committee-scholar flex flex-wrap items-center gap-1">
-                                                @if ($committee->getMeta('orcid_url'))
-                                                    <a href="{{ $committee->getMeta('orcid_url') }}" target="_blank">
-                                                        <x-academicon-orcid class="orcid-logo" />
-                                                    </a>
-                                                @endif
-                                                @if ($committee->getMeta('google_scholar_url'))
-                                                    <a href="{{ $committee->getMeta('google_scholar_url') }}"
-                                                        target="_blank">
-                                                        <x-academicon-google-scholar class="google-scholar-logo" />
-                                                    </a>
-                                                @endif
-                                                @if ($committee->getMeta('scopus_url'))
-                                                    <a href="{{ $committee->getMeta('scopus_url') }}" target="_blank">
-                                                        <x-academicon-scopus class="scopus-logo" />
-                                                    </a>
-                                                @endif
-                                            </div>
-                                        @endif
+                                        @include('frontend.scheduledConference.components.contributor-profile-links', ['person' => $committee])
                                     </div>
                                 </div>
                             @endforeach

--- a/resources/views/frontend/scheduledConference/pages/home.blade.php
+++ b/resources/views/frontend/scheduledConference/pages/home.blade.php
@@ -47,25 +47,7 @@
                                                     <div class="cf-speaker-affiliation text-xs text-gray-700">
                                                         {{ $speaker->getMeta('affiliation') }}</div>
                                                 @endif
-                                                @if($speaker->getMeta('scopus_url') || $speaker->getMeta('google_scholar_url') || $speaker->getMeta('orcid_url'))
-                                                    <div class="cf-committee-scholar flex flex-wrap items-center gap-1">
-                                                        @if($speaker->getMeta('orcid_url'))
-                                                        <a href="{{ $speaker->getMeta('orcid_url') }}" target="_blank">
-                                                            <x-academicon-orcid class="orcid-logo" />
-                                                        </a>
-                                                        @endif
-                                                        @if($speaker->getMeta('google_scholar_url'))
-                                                        <a href="{{ $speaker->getMeta('google_scholar_url') }}" target="_blank">
-                                                            <x-academicon-google-scholar class="google-scholar-logo" />
-                                                        </a>
-                                                        @endif
-                                                        @if($speaker->getMeta('scopus_url'))
-                                                        <a href="{{ $speaker->getMeta('scopus_url') }}" target="_blank">
-                                                            <x-academicon-scopus class="scopus-logo" />
-                                                        </a>
-                                                        @endif
-                                                    </div>
-                                                @endif
+                                                @include('frontend.scheduledConference.components.contributor-profile-links', ['person' => $speaker])
                                             </div>
                                         </div>
                                     @endforeach

--- a/tests/Feature/ContributorListTest.php
+++ b/tests/Feature/ContributorListTest.php
@@ -29,7 +29,7 @@ class ContributorListTest extends TestCase
 
         $this->actingAs($context['user']);
 
-        Livewire::test(ContributorList::class, ['submission' => $context['submission']])
+        $component = Livewire::test(ContributorList::class, ['submission' => $context['submission']])
             ->assertFormFieldDoesNotExist('author_id')
             ->assertFormFieldExists('profile', fn ($field): bool => ! array_key_exists(
                 'x-on:update-profile-image.window',
@@ -37,6 +37,10 @@ class ContributorListTest extends TestCase
             ))
             ->assertFormFieldExists('given_name')
             ->assertFormFieldExists('email');
+
+        foreach (config('app.contributor_profile_links', []) as $profile) {
+            $component->assertFormFieldExists('meta.'.$profile['meta']);
+        }
     }
 
     public function test_speaker_and_committee_create_forms_do_not_offer_existing_person_selection(): void
@@ -46,7 +50,7 @@ class ContributorListTest extends TestCase
         $this->actingAs($context['user']);
         Gate::before(fn () => true);
 
-        Livewire::test(ManageSpeakers::class)
+        $speaker = Livewire::test(ManageSpeakers::class)
             ->mountTableAction('create')
             ->assertFormFieldDoesNotExist('speaker_id', 'mountedTableActionForm')
             ->assertFormFieldExists('profile', 'mountedTableActionForm', fn ($field): bool => ! array_key_exists(
@@ -56,7 +60,11 @@ class ContributorListTest extends TestCase
             ->assertFormFieldExists('given_name', 'mountedTableActionForm')
             ->assertFormFieldExists('email', 'mountedTableActionForm');
 
-        Livewire::test(ManageCommittee::class)
+        foreach (config('app.contributor_profile_links', []) as $profile) {
+            $speaker->assertFormFieldExists('meta.'.$profile['meta'], 'mountedTableActionForm');
+        }
+
+        $committee = Livewire::test(ManageCommittee::class)
             ->mountTableAction('create')
             ->assertFormFieldDoesNotExist('committee_id', 'mountedTableActionForm')
             ->assertFormFieldExists('profile', 'mountedTableActionForm', fn ($field): bool => ! array_key_exists(
@@ -65,6 +73,10 @@ class ContributorListTest extends TestCase
             ))
             ->assertFormFieldExists('given_name', 'mountedTableActionForm')
             ->assertFormFieldExists('email', 'mountedTableActionForm');
+
+        foreach (config('app.contributor_profile_links', []) as $profile) {
+            $committee->assertFormFieldExists('meta.'.$profile['meta'], 'mountedTableActionForm');
+        }
     }
 
     public function test_wizard_owner_can_add_themselves_as_contributor(): void

--- a/tests/Feature/ContributorProfileLinksTest.php
+++ b/tests/Feature/ContributorProfileLinksTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class ContributorProfileLinksTest extends TestCase
+{
+    public function test_configured_profile_links_are_rendered_for_a_contributor(): void
+    {
+        $person = new class
+        {
+            public function getMeta(string $key): ?string
+            {
+                return match ($key) {
+                    'orcid_url' => 'https://orcid.org/0000-0000-0000-0001',
+                    'research_gate_url' => 'https://www.researchgate.net/profile/test',
+                    default => null,
+                };
+            }
+        };
+
+        $html = view('frontend.scheduledConference.components.contributor-profile-links', compact('person'))
+            ->render();
+
+        $this->assertStringContainsString('https://orcid.org/0000-0000-0000-0001', $html);
+        $this->assertStringContainsString('https://www.researchgate.net/profile/test', $html);
+        $this->assertStringContainsString('cf-contributor-profile-links', $html);
+        $this->assertStringContainsString('contributor-profile-logo', $html);
+    }
+}


### PR DESCRIPTION
## Summary

- add ResearchGate as a contributor profile link
- centralize contributor profile link definitions in config/app.php
- render contributor profile links through one shared frontend component
- keep existing contributor meta keys and add registry-driven form and rendering tests

## Why

Contributor profile providers should not require updating each form and public page separately when a new provider is requested.

## Validation

- php artisan test — 221 passed, 957 assertions
- npm run build
- vendor/bin/pint --test
- git diff --cached --check
